### PR TITLE
Feat/gh1460 remove digit verification reqs

### DIFF
--- a/CDP4Composition/Services/ImeValidationService.cs
+++ b/CDP4Composition/Services/ImeValidationService.cs
@@ -42,6 +42,21 @@ namespace CDP4Composition.Services
     public class ImeValidationService : ValidationService, IImeValidationService
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ImeValidationService" /> class.
+        /// </summary>
+        public ImeValidationService()
+        {
+            // Allow a Requirement, RequirementsGroup or RequirementsSpecification Name to start with a digit (see GitHub issue #1460).
+            // Same intent as the default "Name" rule, but the first character may also be a digit.
+            this.ValidationMap["RequirementName"] = new ValidationRule
+            {
+                PropertyName = "Name",
+                Rule = @"^([\p{L}\d]|[\p{L}\d][^()]*[^()\s])$",
+                ErrorText = "The Name must start with a letter or a digit and not contain any parentheses or trailing spaces."
+            };
+        }
+
+        /// <summary>
         /// Validates a property of a <see cref="DialogViewModelBase{T}" />.
         /// </summary>
         /// <param name="propertyName">

--- a/CDP4Composition/Services/ImeValidationService.cs
+++ b/CDP4Composition/Services/ImeValidationService.cs
@@ -50,7 +50,7 @@ namespace CDP4Composition.Services
             // Same intent as the default "Name" rule, but the first character may also be a digit.
             this.ValidationMap["RequirementName"] = new ValidationRule
             {
-                PropertyName = "Name",
+                PropertyName = nameof(DefinedThing.Name),
                 Rule = @"^([\p{L}\d]|[\p{L}\d][^()]*[^()\s])$",
                 ErrorText = "The Name must start with a letter or a digit and not contain any parentheses or trailing spaces."
             };

--- a/CDP4Composition/Services/ImeValidationService.cs
+++ b/CDP4Composition/Services/ImeValidationService.cs
@@ -46,7 +46,7 @@ namespace CDP4Composition.Services
         /// </summary>
         public ImeValidationService()
         {
-            // Allow a Requirement, RequirementsGroup or RequirementsSpecification Name to start with a digit (see GitHub issue #1460).
+            // Allow a Requirement, RequirementsGroup or RequirementsSpecification Name to start with a digit.
             // Same intent as the default "Name" rule, but the first character may also be a digit.
             this.ValidationMap["RequirementName"] = new ValidationRule
             {

--- a/Requirements.Tests/Dialogs/RequirementDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementDialogViewModelTestFixture.cs
@@ -200,6 +200,19 @@ namespace CDP4Requirements.Tests.Dialogs
         }
 
         [Test]
+        public void VerifyThatNameAndShortNameCanStartWithADigit()
+        {
+            var vm = new RequirementDialogViewModel(this.requirement, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.clone);
+
+            vm.ShortName = "1req";
+            vm.Name = "1 req";
+
+            Assert.That(vm["ShortName"], Is.Null);
+            Assert.That(vm["Name"], Is.Null);
+        }
+
+        [Test]
         public void VerifyThatPopulateGroupsWorks()
         {
             var vm = new RequirementDialogViewModel(this.requirement, this.thingTransaction, this.session.Object,

--- a/Requirements.Tests/Dialogs/RequirementDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementDialogViewModelTestFixture.cs
@@ -208,8 +208,11 @@ namespace CDP4Requirements.Tests.Dialogs
             vm.ShortName = "1req";
             vm.Name = "1 req";
 
-            Assert.That(vm["ShortName"], Is.Null);
-            Assert.That(vm["Name"], Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm["ShortName"], Is.Null);
+                Assert.That(vm["Name"], Is.Null);
+            });
         }
 
         [Test]

--- a/Requirements.Tests/Dialogs/RequirementsGroupDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementsGroupDialogViewModelTestFixture.cs
@@ -177,5 +177,21 @@ namespace CDP4Requirements.Tests.Dialogs
             Assert.That(((ICommand)vm.CreateGroupCommand).CanExecute(null), Is.False);
             Assert.That(((ICommand)vm.EditGroupCommand).CanExecute(null), Is.False);
         }
+
+        [Test]
+        public void VerifyThatNameAndShortNameCanStartWithADigit()
+        {
+            var clone = this.reqSpec.Clone(true);
+            this.thingTransaction.CreateOrUpdate(clone);
+
+            var vm = new RequirementsGroupDialogViewModel(this.reqGroup, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Create, null, clone);
+
+            vm.ShortName = "1group";
+            vm.Name = "1 group";
+
+            Assert.That(vm["ShortName"], Is.Null);
+            Assert.That(vm["Name"], Is.Null);
+        }
     }
 }

--- a/Requirements.Tests/Dialogs/RequirementsGroupDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementsGroupDialogViewModelTestFixture.cs
@@ -190,8 +190,11 @@ namespace CDP4Requirements.Tests.Dialogs
             vm.ShortName = "1group";
             vm.Name = "1 group";
 
-            Assert.That(vm["ShortName"], Is.Null);
-            Assert.That(vm["Name"], Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm["ShortName"], Is.Null);
+                Assert.That(vm["Name"], Is.Null);
+            });
         }
     }
 }

--- a/Requirements.Tests/Dialogs/RequirementsSpecificationDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementsSpecificationDialogViewModelTestFixture.cs
@@ -172,8 +172,11 @@ namespace CDP4Requirements.Tests
             this.viewmodel.ShortName = "1spec";
             this.viewmodel.Name = "1 spec";
 
-            Assert.That(this.viewmodel["ShortName"], Is.Null);
-            Assert.That(this.viewmodel["Name"], Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.viewmodel["ShortName"], Is.Null);
+                Assert.That(this.viewmodel["Name"], Is.Null);
+            });
         }
 
         [Test]

--- a/Requirements.Tests/Dialogs/RequirementsSpecificationDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementsSpecificationDialogViewModelTestFixture.cs
@@ -167,6 +167,16 @@ namespace CDP4Requirements.Tests
         }
 
         [Test]
+        public void VerifyThatNameAndShortNameCanStartWithADigit()
+        {
+            this.viewmodel.ShortName = "1spec";
+            this.viewmodel.Name = "1 spec";
+
+            Assert.That(this.viewmodel["ShortName"], Is.Null);
+            Assert.That(this.viewmodel["Name"], Is.Null);
+        }
+
+        [Test]
         public async Task VerifyThatOkCommandWorks()
         {
             await this.viewmodel.OkCommand.Execute();

--- a/Requirements/ViewModels/Dialogs/RequirementDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementDialogViewModel.cs
@@ -66,6 +66,11 @@ namespace CDP4Requirements.ViewModels
         private string shortName;
 
         /// <summary>
+        /// Backing field for <see cref="Name"/> property
+        /// </summary>
+        private string name;
+
+        /// <summary>
         /// The Required Referance-Data-library for the current <see cref="Iteration"/>
         /// </summary>
         private ModelReferenceDataLibrary mRdl;
@@ -214,6 +219,16 @@ namespace CDP4Requirements.ViewModels
         {
             get { return this.shortName; }
             set { this.RaiseAndSetIfChanged(ref this.shortName, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the Name
+        /// </summary>
+        [ValidationOverride(true, "RequirementName")]
+        public override string Name
+        {
+            get { return this.name; }
+            set { this.RaiseAndSetIfChanged(ref this.name, value); }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/Dialogs/RequirementsGroupDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementsGroupDialogViewModel.cs
@@ -55,6 +55,16 @@ namespace CDP4Requirements.ViewModels
         private ModelReferenceDataLibrary mRdl;
 
         /// <summary>
+        /// Backing field for <see cref="ShortName"/> property
+        /// </summary>
+        private string shortName;
+
+        /// <summary>
+        /// Backing field for <see cref="Name"/> property
+        /// </summary>
+        private string name;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RequirementsGroupDialogViewModel"/> class.
         /// </summary>
         /// <remarks>
@@ -91,6 +101,26 @@ namespace CDP4Requirements.ViewModels
         public RequirementsGroupDialogViewModel(RequirementsGroup requirementsGroup, IThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, IThingDialogNavigationService thingDialogNavigationService, Thing container = null, IEnumerable<Thing> chainOfContainers = null)
             : base(requirementsGroup, transaction, session, isRoot, dialogKind, thingDialogNavigationService, container, chainOfContainers)
         {
+        }
+
+        /// <summary>
+        /// Gets or sets the ShortName
+        /// </summary>
+        [ValidationOverride(true, "RequirementShortName")]
+        public override string ShortName
+        {
+            get { return this.shortName; }
+            set { this.RaiseAndSetIfChanged(ref this.shortName, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the Name
+        /// </summary>
+        [ValidationOverride(true, "RequirementName")]
+        public override string Name
+        {
+            get { return this.name; }
+            set { this.RaiseAndSetIfChanged(ref this.name, value); }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/Dialogs/RequirementsGroupDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementsGroupDialogViewModel.cs
@@ -42,6 +42,8 @@ namespace CDP4Requirements.ViewModels
     using CDP4Dal;
     using CDP4Dal.Operations;
 
+    using ReactiveUI;
+
     /// <summary>
     /// The purpose of the <see cref="RequirementsGroupDialogViewModel"/> is to provide a dialog view model
     /// for a <see cref="RequirementsGroup"/>

--- a/Requirements/ViewModels/Dialogs/RequirementsSpecificationDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementsSpecificationDialogViewModel.cs
@@ -65,6 +65,11 @@ namespace CDP4Requirements.ViewModels
         private string shortName;
 
         /// <summary>
+        /// Backing field for <see cref="Name"/> property
+        /// </summary>
+        private string name;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RequirementsSpecificationDialogViewModel"/> class.
         /// </summary>
         /// <remarks>
@@ -137,6 +142,16 @@ namespace CDP4Requirements.ViewModels
         {
             get => this.shortName;
             set => this.RaiseAndSetIfChanged(ref this.shortName, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the Name
+        /// </summary>
+        [ValidationOverride(true, "RequirementName")]
+        public override string Name
+        {
+            get => this.name;
+            set => this.RaiseAndSetIfChanged(ref this.name, value);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes #1460

Allows requirements, requirement groups and requirement specifications to have a Name and ShortName that start with a digit. This makes it possible to control the display order of elements in a specification instead of being limited to alphabetical order.

### Changes

- Added a `RequirementName` validation rule to `ImeValidationService` that mirrors the default Name rule but permits a leading digit.
- Applied `[ValidationOverride]` on both Name and ShortName in the Requirement, RequirementsSpecification and RequirementsGroup dialogs so both fields accept a leading digit.


