### PR TITLE
Feat #1462 Add Multiple Participants in Team Composition and made it also per row possible to change set role and activity

### DIFF
--- a/CDP4SiteDirectory.Tests/Dialogs/BulkParticipantCreationDialogViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/Dialogs/BulkParticipantCreationDialogViewModelTestFixture.cs
@@ -190,8 +190,11 @@ namespace CDP4SiteDirectory.Tests.Dialogs
             // overriding a single person keeps the others on the global role
             this.RowFor(viewModel, this.john).SelectedRole = adminRole;
 
-            Assert.That(this.RowFor(viewModel, this.john).SelectedRole, Is.EqualTo(adminRole));
-            Assert.That(this.RowFor(viewModel, this.jane).SelectedRole, Is.EqualTo(this.role));
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.RowFor(viewModel, this.john).SelectedRole, Is.EqualTo(adminRole));
+                Assert.That(this.RowFor(viewModel, this.jane).SelectedRole, Is.EqualTo(this.role));
+            });
         }
 
         [Test]
@@ -212,8 +215,12 @@ namespace CDP4SiteDirectory.Tests.Dialogs
             var result = viewModel.DialogResult as BulkParticipantCreationResult;
 
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Participants.Single(x => x.Person == this.john).SelectedRole, Is.EqualTo(adminRole));
-            Assert.That(result.Participants.Single(x => x.Person == this.jane).SelectedRole, Is.EqualTo(this.role));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Participants.Single(x => x.Person == this.john).SelectedRole, Is.EqualTo(adminRole));
+                Assert.That(result.Participants.Single(x => x.Person == this.jane).SelectedRole, Is.EqualTo(this.role));
+            });
         }
 
         [Test]
@@ -233,8 +240,12 @@ namespace CDP4SiteDirectory.Tests.Dialogs
             var result = viewModel.DialogResult as BulkParticipantCreationResult;
 
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Participants.Single(x => x.Person == this.john).IsActive, Is.False);
-            Assert.That(result.Participants.Single(x => x.Person == this.jane).IsActive, Is.True);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Participants.Single(x => x.Person == this.john).IsActive, Is.False);
+                Assert.That(result.Participants.Single(x => x.Person == this.jane).IsActive, Is.True);
+            });
         }
 
         [Test]

--- a/CDP4SiteDirectory.Tests/Dialogs/BulkParticipantCreationDialogViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/Dialogs/BulkParticipantCreationDialogViewModelTestFixture.cs
@@ -173,6 +173,71 @@ namespace CDP4SiteDirectory.Tests.Dialogs
         }
 
         [Test]
+        public void VerifyThatDefaultRoleIsAppliedToAllRowsButCanBeOverriddenPerPerson()
+        {
+            var adminRole = new ParticipantRole(Guid.NewGuid(), this.cache, this.uri) { Name = "Model Administrator" };
+
+            var viewModel = new BulkParticipantCreationDialogViewModel(
+                new[] { this.john, this.jane },
+                new[] { this.role, adminRole },
+                new[] { this.thermal, this.systems });
+
+            viewModel.SelectedRole = this.role;
+
+            // the global role seeds every row
+            Assert.That(viewModel.Participants.All(x => x.SelectedRole == this.role), Is.True);
+
+            // overriding a single person keeps the others on the global role
+            this.RowFor(viewModel, this.john).SelectedRole = adminRole;
+
+            Assert.That(this.RowFor(viewModel, this.john).SelectedRole, Is.EqualTo(adminRole));
+            Assert.That(this.RowFor(viewModel, this.jane).SelectedRole, Is.EqualTo(this.role));
+        }
+
+        [Test]
+        public async Task VerifyThatPerPersonRoleOverrideSurvivesOk()
+        {
+            var adminRole = new ParticipantRole(Guid.NewGuid(), this.cache, this.uri) { Name = "Model Administrator" };
+
+            var viewModel = new BulkParticipantCreationDialogViewModel(
+                new[] { this.john, this.jane },
+                new[] { this.role, adminRole },
+                new[] { this.thermal, this.systems });
+
+            viewModel.SelectedRole = this.role;
+            this.RowFor(viewModel, this.john).SelectedRole = adminRole;
+
+            await viewModel.OkCommand.Execute();
+
+            var result = viewModel.DialogResult as BulkParticipantCreationResult;
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Participants.Single(x => x.Person == this.john).SelectedRole, Is.EqualTo(adminRole));
+            Assert.That(result.Participants.Single(x => x.Person == this.jane).SelectedRole, Is.EqualTo(this.role));
+        }
+
+        [Test]
+        public async Task VerifyThatPerPersonIsActiveOverrideSurvivesOk()
+        {
+            var viewModel = this.CreateDialogViewModel();
+
+            viewModel.SelectedRole = this.role;
+            viewModel.IsActive = true;
+            this.RowFor(viewModel, this.personWithoutDefaultDomain).SelectedDomain = this.thermal;
+
+            // the default seeds every row active; a single person is then set inactive
+            this.RowFor(viewModel, this.john).IsActive = false;
+
+            await viewModel.OkCommand.Execute();
+
+            var result = viewModel.DialogResult as BulkParticipantCreationResult;
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Participants.Single(x => x.Person == this.john).IsActive, Is.False);
+            Assert.That(result.Participants.Single(x => x.Person == this.jane).IsActive, Is.True);
+        }
+
+        [Test]
         public async Task VerifyThatOkResultContainsOnlySelectedParticipants()
         {
             var viewModel = this.CreateDialogViewModel();

--- a/CDP4SiteDirectory.Tests/ModelBrowser/ModelBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/ModelBrowser/ModelBrowserViewModelTestFixture.cs
@@ -623,7 +623,7 @@ namespace CDP4SiteDirectory.Tests
 
             Assert.IsTrue(viewmodel.CanCreateParticipant);
 
-            var row = new BulkParticipantRowViewModel(newPerson, new[] { domain })
+            var row = new BulkParticipantRowViewModel(newPerson, new[] { domain }, new[] { role })
             {
                 SelectedRole = role,
                 SelectedDomain = domain,

--- a/CDP4SiteDirectory.Tests/TeamComposition/TeamCompositionBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/TeamComposition/TeamCompositionBrowserViewModelTestFixture.cs
@@ -29,7 +29,9 @@ namespace CDP4SiteDirectory.Tests
     using System.Collections.Concurrent;
     using System.Linq;
     using System.Reactive.Concurrency;
+    using System.Reactive.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
 
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
@@ -40,6 +42,7 @@ namespace CDP4SiteDirectory.Tests
 
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
     using CDP4Dal.Permission;
 
     using CDP4SiteDirectory.ViewModels;
@@ -191,6 +194,43 @@ namespace CDP4SiteDirectory.Tests
             this.messageBus.SendObjectChangeEvent(this.engineeringModelSetup, EventKind.Updated);
 
             Assert.AreEqual(2, vm.Participants.Count);
+        }
+
+        [Test]
+        public async Task VerifyThatCreateMultipleParticipantsCommandWritesParticipants()
+        {
+            this.siteDir.Model.Add(this.engineeringModelSetup);
+            this.siteDir.ParticipantRole.Add(this.participantRole);
+            this.siteDir.Domain.Add(this.systemEngineering);
+            this.engineeringModelSetup.ActiveDomain.Add(this.systemEngineering);
+
+            var newPerson = new Person(Guid.NewGuid(), this.cache, this.uri) { GivenName = "Jane", Surname = "Roe", Role = this.personRole };
+            this.siteDir.Person.Add(newPerson);
+
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+            this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDir);
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>())).Returns(Task.CompletedTask);
+
+            var vm = new TeamCompositionBrowserViewModel(this.engineeringModelSetup, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, null);
+            vm.ComputePermission();
+
+            Assert.IsTrue(vm.CanCreateParticipant);
+
+            var row = new BulkParticipantRowViewModel(newPerson, new[] { this.systemEngineering }, new[] { this.participantRole })
+            {
+                SelectedRole = this.participantRole,
+                SelectedDomain = this.systemEngineering,
+                IsActive = true
+            };
+
+            this.dialogNavigationService
+                .Setup(x => x.NavigateModal(It.IsAny<IDialogViewModel>()))
+                .Returns(new BulkParticipantCreationResult(true, new[] { row }));
+
+            await vm.CreateMultipleParticipantsCommand.Execute();
+
+            this.dialogNavigationService.Verify(x => x.NavigateModal(It.IsAny<IDialogViewModel>()), Times.Once);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
         }
 
         [Test]

--- a/CDP4SiteDirectory.Tests/TeamComposition/TeamCompositionBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/TeamComposition/TeamCompositionBrowserViewModelTestFixture.cs
@@ -214,7 +214,7 @@ namespace CDP4SiteDirectory.Tests
             var vm = new TeamCompositionBrowserViewModel(this.engineeringModelSetup, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, null);
             vm.ComputePermission();
 
-            Assert.IsTrue(vm.CanCreateParticipant);
+            Assert.That(vm.CanCreateParticipant, Is.True);
 
             var row = new BulkParticipantRowViewModel(newPerson, new[] { this.systemEngineering }, new[] { this.participantRole })
             {
@@ -229,8 +229,11 @@ namespace CDP4SiteDirectory.Tests
 
             await vm.CreateMultipleParticipantsCommand.Execute();
 
-            this.dialogNavigationService.Verify(x => x.NavigateModal(It.IsAny<IDialogViewModel>()), Times.Once);
-            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+            Assert.Multiple(() =>
+            {
+                this.dialogNavigationService.Verify(x => x.NavigateModal(It.IsAny<IDialogViewModel>()), Times.Once);
+                this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+            });
         }
 
         [Test]

--- a/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantCreationDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantCreationDialogViewModel.cs
@@ -39,10 +39,10 @@ namespace CDP4SiteDirectory.ViewModels
 
     /// <summary>
     /// The dialog-view-model that allows the user to create multiple <see cref="Participant"/>s at once for a single
-    /// <see cref="EngineeringModelSetup"/>. The selected <see cref="Person"/>s all receive the same
-    /// <see cref="ParticipantRole"/> and active state, while the <see cref="DomainOfExpertise"/> of each
-    /// <see cref="Participant"/> is chosen per <see cref="Person"/> (defaulting to the <see cref="Person"/>'s own
-    /// default domain).
+    /// <see cref="EngineeringModelSetup"/>. The <see cref="SelectedRole"/> and active state chosen on the dialog are
+    /// applied to every selected <see cref="Person"/> as a default, while the <see cref="DomainOfExpertise"/> and the
+    /// <see cref="ParticipantRole"/> may be overridden per <see cref="Person"/> (the domain defaulting to the
+    /// <see cref="Person"/>'s own default domain).
     /// </summary>
     public class BulkParticipantCreationDialogViewModel : DialogViewModelBase
     {
@@ -97,12 +97,13 @@ namespace CDP4SiteDirectory.ViewModels
 
             foreach (var person in persons.OrderBy(x => x.Name))
             {
-                var row = new BulkParticipantRowViewModel(person, this.PossibleDomain);
-                this.Subscriptions.Add(row.WhenAnyValue(x => x.IsSelected, x => x.SelectedDomain).Subscribe(_ => this.UpdateOkCanExecute()));
+                var row = new BulkParticipantRowViewModel(person, this.PossibleDomain, this.PossibleRole);
+                this.Subscriptions.Add(row.WhenAnyValue(x => x.IsSelected, x => x.SelectedDomain, x => x.SelectedRole).Subscribe(_ => this.UpdateOkCanExecute()));
                 this.Participants.Add(row);
             }
 
-            this.Subscriptions.Add(this.WhenAnyValue(x => x.SelectedRole).Subscribe(_ => this.UpdateOkCanExecute()));
+            this.Subscriptions.Add(this.WhenAnyValue(x => x.SelectedRole).Subscribe(this.ApplyRoleToRows));
+            this.Subscriptions.Add(this.WhenAnyValue(x => x.IsActive).Subscribe(this.ApplyIsActiveToRows));
 
             this.InitializeReactiveCommands();
             this.UpdateOkCanExecute();
@@ -124,7 +125,9 @@ namespace CDP4SiteDirectory.ViewModels
         public IReadOnlyList<DomainOfExpertise> PossibleDomain { get; private set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="ParticipantRole"/> that every created <see cref="Participant"/> shall receive.
+        /// Gets or sets the default <see cref="ParticipantRole"/> that is applied to every selected
+        /// <see cref="Person"/>. The role of an individual <see cref="Person"/> may still be overridden on its
+        /// <see cref="BulkParticipantRowViewModel"/>.
         /// </summary>
         public ParticipantRole SelectedRole
         {
@@ -133,7 +136,9 @@ namespace CDP4SiteDirectory.ViewModels
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether every created <see cref="Participant"/> shall be active.
+        /// Gets or sets the default value applied to every selected <see cref="Person"/> indicating whether the
+        /// created <see cref="Participant"/> shall be active. The active state of an individual <see cref="Person"/>
+        /// may still be overridden on its <see cref="BulkParticipantRowViewModel"/>.
         /// </summary>
         public bool IsActive
         {
@@ -170,13 +175,43 @@ namespace CDP4SiteDirectory.ViewModels
         }
 
         /// <summary>
+        /// Applies the batch-wide <see cref="SelectedRole"/> to every row as the default role for each
+        /// <see cref="Person"/>. Individual rows may subsequently be overridden by the user.
+        /// </summary>
+        /// <param name="role">
+        /// The <see cref="ParticipantRole"/> to apply to every row.
+        /// </param>
+        private void ApplyRoleToRows(ParticipantRole role)
+        {
+            foreach (var row in this.Participants)
+            {
+                row.SelectedRole = role;
+            }
+        }
+
+        /// <summary>
+        /// Applies the batch-wide <see cref="IsActive"/> value to every row as the default for each
+        /// <see cref="Person"/>. Individual rows may subsequently be overridden by the user.
+        /// </summary>
+        /// <param name="isActive">
+        /// A value indicating whether the created <see cref="Participant"/>s shall be active.
+        /// </param>
+        private void ApplyIsActiveToRows(bool isActive)
+        {
+            foreach (var row in this.Participants)
+            {
+                row.IsActive = isActive;
+            }
+        }
+
+        /// <summary>
         /// Updates the <see cref="OkCanExecute"/> property.
         /// </summary>
         private void UpdateOkCanExecute()
         {
             var selectedRows = this.Participants.Where(x => x.IsSelected).ToList();
 
-            this.OkCanExecute = selectedRows.Any() && this.SelectedRole != null && selectedRows.All(x => x.SelectedDomain != null);
+            this.OkCanExecute = selectedRows.Any() && selectedRows.All(x => x.SelectedDomain != null && x.SelectedRole != null);
         }
 
         /// <summary>
@@ -185,12 +220,6 @@ namespace CDP4SiteDirectory.ViewModels
         private void ExecuteOk()
         {
             var selectedRows = this.Participants.Where(x => x.IsSelected).ToList();
-
-            foreach (var row in selectedRows)
-            {
-                row.SelectedRole = this.SelectedRole;
-                row.IsActive = this.IsActive;
-            }
 
             this.DialogResult = new BulkParticipantCreationResult(true, selectedRows);
         }

--- a/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantRowViewModel.cs
@@ -35,9 +35,9 @@ namespace CDP4SiteDirectory.ViewModels
     /// <summary>
     /// Represents a single candidate <see cref="Participant"/> to be created in the
     /// <see cref="BulkParticipantCreationDialogViewModel"/>. Each row maps one <see cref="Person"/> to the
-    /// <see cref="DomainOfExpertise"/> the created <see cref="Participant"/> shall receive. The
-    /// <see cref="ParticipantRole"/> and active state are applied for the whole batch by the owning
-    /// <see cref="BulkParticipantCreationDialogViewModel"/>.
+    /// <see cref="DomainOfExpertise"/> and <see cref="ParticipantRole"/> the created <see cref="Participant"/>
+    /// shall receive. The <see cref="ParticipantRole"/> defaults to the batch-wide role set on the owning
+    /// <see cref="BulkParticipantCreationDialogViewModel"/> but may be overridden per <see cref="Person"/>.
     /// </summary>
     public class BulkParticipantRowViewModel : ReactiveObject
     {
@@ -52,6 +52,16 @@ namespace CDP4SiteDirectory.ViewModels
         private DomainOfExpertise selectedDomain;
 
         /// <summary>
+        /// Backing field for <see cref="SelectedRole"/>
+        /// </summary>
+        private ParticipantRole selectedRole;
+
+        /// <summary>
+        /// Backing field for <see cref="IsActive"/>
+        /// </summary>
+        private bool isActive;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BulkParticipantRowViewModel"/> class.
         /// </summary>
         /// <param name="person">
@@ -60,10 +70,14 @@ namespace CDP4SiteDirectory.ViewModels
         /// <param name="possibleDomains">
         /// The possible <see cref="DomainOfExpertise"/>s (the active domains of the model) that may be assigned.
         /// </param>
-        public BulkParticipantRowViewModel(Person person, IEnumerable<DomainOfExpertise> possibleDomains)
+        /// <param name="possibleRoles">
+        /// The possible <see cref="ParticipantRole"/>s that may be assigned to this <see cref="Person"/>.
+        /// </param>
+        public BulkParticipantRowViewModel(Person person, IEnumerable<DomainOfExpertise> possibleDomains, IEnumerable<ParticipantRole> possibleRoles)
         {
             this.Person = person;
             this.PossibleDomain = possibleDomains.ToList();
+            this.PossibleRole = possibleRoles.ToList();
             this.IsSelected = true;
 
             if (person.DefaultDomain != null && this.PossibleDomain.Contains(person.DefaultDomain))
@@ -88,6 +102,11 @@ namespace CDP4SiteDirectory.ViewModels
         public IReadOnlyList<DomainOfExpertise> PossibleDomain { get; }
 
         /// <summary>
+        /// Gets the possible <see cref="ParticipantRole"/>s that may be assigned to this <see cref="Person"/>.
+        /// </summary>
+        public IReadOnlyList<ParticipantRole> PossibleRole { get; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether a <see cref="Participant"/> shall be created for this <see cref="Person"/>.
         /// </summary>
         public bool IsSelected
@@ -108,11 +127,19 @@ namespace CDP4SiteDirectory.ViewModels
         /// <summary>
         /// Gets or sets the <see cref="ParticipantRole"/> that the created <see cref="Participant"/> shall receive.
         /// </summary>
-        public ParticipantRole SelectedRole { get; set; }
+        public ParticipantRole SelectedRole
+        {
+            get => this.selectedRole;
+            set => this.RaiseAndSetIfChanged(ref this.selectedRole, value);
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether the created <see cref="Participant"/> shall be active.
         /// </summary>
-        public bool IsActive { get; set; }
+        public bool IsActive
+        {
+            get => this.isActive;
+            set => this.RaiseAndSetIfChanged(ref this.isActive, value);
+        }
     }
 }

--- a/CDP4SiteDirectory/ViewModels/ModelBrowser/ModelBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/ModelBrowser/ModelBrowserViewModel.cs
@@ -250,8 +250,9 @@ namespace CDP4SiteDirectory.ViewModels
 
             foreach (var row in result.Participants)
             {
-                var participant = new Participant(Guid.NewGuid(), null, null)
+                var participant = new Participant
                 {
+                    Iid = Guid.NewGuid(),
                     Person = row.Person,
                     Role = row.SelectedRole,
                     SelectedDomain = row.SelectedDomain,

--- a/CDP4SiteDirectory/ViewModels/TeamComposition/TeamCompositionBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/TeamComposition/TeamCompositionBrowserViewModel.cs
@@ -208,8 +208,9 @@ namespace CDP4SiteDirectory.ViewModels
 
             foreach (var row in result.Participants)
             {
-                var participant = new Participant(Guid.NewGuid(), null, null)
+                var participant = new Participant
                 {
+                    Iid = Guid.NewGuid(),
                     Person = row.Person,
                     Role = row.SelectedRole,
                     SelectedDomain = row.SelectedDomain,

--- a/CDP4SiteDirectory/ViewModels/TeamComposition/TeamCompositionBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/TeamComposition/TeamCompositionBrowserViewModel.cs
@@ -1,23 +1,49 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TeamCompositionBrowserViewModel.cs" company="Starion Group S.A.">
-//   Copyright (c) 2015-2020 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4SiteDirectory.ViewModels
 {
     using System;
     using System.Linq;
+    using System.Reactive;
+    using System.Threading.Tasks;
+
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
+
     using CDP4Composition;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Mvvm.Types;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
+
     using ReactiveUI;
 
     /// <summary>
@@ -106,6 +132,11 @@ namespace CDP4SiteDirectory.ViewModels
         }
 
         /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> to create multiple <see cref="Participant"/>s at once
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> CreateMultipleParticipantsCommand { get; private set; }
+
+        /// <summary>
         /// Gets or sets the dock layout group target name to attach this panel to on opening
         /// </summary>
         public string TargetName { get; set; } = LayoutGroupNames.DocumentContainer;
@@ -133,6 +164,65 @@ namespace CDP4SiteDirectory.ViewModels
         {
             base.InitializeCommands();
             this.CreateCommand = ReactiveCommandCreator.Create(() => this.ExecuteCreateCommand<Participant>(this.Thing), this.WhenAnyValue(x => x.CanCreateParticipant));
+
+            this.CreateMultipleParticipantsCommand = ReactiveCommandCreator.CreateAsyncTask(
+                this.ExecuteCreateMultipleParticipantsCommand,
+                this.WhenAnyValue(x => x.CanCreateParticipant));
+        }
+
+        /// <summary>
+        /// Executes the <see cref="CreateMultipleParticipantsCommand"/> by presenting the bulk participant creation
+        /// dialog and persisting the selected <see cref="Participant"/>s in a single transaction.
+        /// </summary>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private async Task ExecuteCreateMultipleParticipantsCommand()
+        {
+            var modelSetup = this.Thing;
+
+            var siteDirectory = this.Session.RetrieveSiteDirectory();
+
+            var eligiblePersons = siteDirectory.Person
+                .Where(person => !person.IsDeprecated)
+                .Except(modelSetup.Participant.Select(p => p.Person))
+                .ToList();
+
+            if (!eligiblePersons.Any())
+            {
+                return;
+            }
+
+            var dialogViewModel = new BulkParticipantCreationDialogViewModel(eligiblePersons, siteDirectory.ParticipantRole, modelSetup.ActiveDomain);
+
+            var result = this.DialogNavigationService.NavigateModal(dialogViewModel) as BulkParticipantCreationResult;
+
+            if (result?.Result != true || result.Participants == null || !result.Participants.Any())
+            {
+                return;
+            }
+
+            var context = TransactionContextResolver.ResolveContext(modelSetup);
+            var modelSetupClone = modelSetup.Clone(false);
+            var transaction = new ThingTransaction(context, modelSetupClone);
+
+            foreach (var row in result.Participants)
+            {
+                var participant = new Participant(Guid.NewGuid(), null, null)
+                {
+                    Person = row.Person,
+                    Role = row.SelectedRole,
+                    SelectedDomain = row.SelectedDomain,
+                    IsActive = row.IsActive
+                };
+
+                participant.Domain.Add(row.SelectedDomain);
+
+                modelSetupClone.Participant.Add(participant);
+                transaction.Create(participant, modelSetupClone);
+            }
+
+            await this.Session.Write(transaction.FinalizeTransaction());
         }
 
         /// <summary>
@@ -152,6 +242,7 @@ namespace CDP4SiteDirectory.ViewModels
             base.PopulateContextMenu();
 
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Participant", "", this.CreateCommand, MenuItemKind.Create, ClassKind.Participant));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create Multiple Participants", "", this.CreateMultipleParticipantsCommand, MenuItemKind.Create, ClassKind.Participant));
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/Views/Dialogs/BulkParticipantCreationDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/BulkParticipantCreationDialog.xaml
@@ -31,7 +31,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,10,5" VerticalAlignment="Center" Text="Participant Role:" />
+            <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,10,5" VerticalAlignment="Center" Text="Default Participant Role:" />
             <dxe:ComboBoxEdit Grid.Row="0" Grid.Column="1"
                               Margin="0,0,0,5"
                               Name="Role"
@@ -40,7 +40,7 @@
                               EditValue="{Binding SelectedRole, UpdateSourceTrigger=PropertyChanged}"
                               ItemsSource="{Binding PossibleRole}" />
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,10,0" VerticalAlignment="Center" Text="Is Active:" />
+            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,10,0" VerticalAlignment="Center" Text="Default Is Active:" />
             <dxe:CheckEdit Grid.Row="1" Grid.Column="1"
                            Name="IsActiveCheckEdit"
                            HorizontalAlignment="Left"
@@ -94,6 +94,34 @@
                                       DisplayMemberPath="Name"
                                       SelectedItem="{Binding RowData.Row.SelectedDomain, UpdateSourceTrigger=PropertyChanged}"
                                       ItemsSource="{Binding RowData.Row.PossibleDomain}" />
+                        </DataTemplate>
+                    </dxg:GridColumn.CellTemplate>
+                </dxg:GridColumn>
+                <dxg:GridColumn FieldName="SelectedRole"
+                                Header="Participant Role"
+                                HorizontalHeaderContentAlignment="Left"
+                                AllowEditing="True">
+                    <dxg:GridColumn.CellTemplate>
+                        <DataTemplate>
+                            <ComboBox Margin="3"
+                                      Background="White"
+                                      IsEditable="False"
+                                      DisplayMemberPath="Name"
+                                      SelectedItem="{Binding RowData.Row.SelectedRole, UpdateSourceTrigger=PropertyChanged}"
+                                      ItemsSource="{Binding RowData.Row.PossibleRole}" />
+                        </DataTemplate>
+                    </dxg:GridColumn.CellTemplate>
+                </dxg:GridColumn>
+                <dxg:GridColumn FieldName="IsActive"
+                                Header="Active"
+                                Width="55"
+                                AllowEditing="True"
+                                HorizontalHeaderContentAlignment="Center">
+                    <dxg:GridColumn.CellTemplate>
+                        <DataTemplate>
+                            <dxe:CheckEdit HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           IsChecked="{Binding RowData.Row.IsActive, UpdateSourceTrigger=PropertyChanged}" />
                         </DataTemplate>
                     </dxg:GridColumn.CellTemplate>
                 </dxg:GridColumn>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Add Multiple Participants in Team Composition (#1462)

### Summary
Adds the "Create Multiple Participants" action to the Team Composition browser, which was previously only available from the Model Browser. The bulk creation dialog is also improved so participant role and active state can be set globally for the whole batch and then overridden per person.

### Changes
- Team Composition browser now exposes a "Create Multiple Participants" context menu command that opens the existing bulk participant creation dialog and persists all selected participants in a single transaction.
- The bulk dialog's top controls now act as defaults:
  - "Default Participant Role" seeds the role of every selected person.
  - "Default Is Active" seeds the active state of every selected person.
- Each person row can override the seeded values individually:
  - Per row "Participant Role" combo box (for example set one person as Model Administrator while the rest keep the default role).
  - Per row "Active" checkbox (add some people as inactive and others as active in the same batch).
- Domain of Expertise remains selectable per person, defaulting to the person's own default domain.

### Notes
- Changing a default value re-applies it to every row, including manual overrides. This matches the intended "set the global value, then tweak individuals" flow.

