### PR TITLE
Feat #1466 Configurable relationship traceability diagram

### DIFF
--- a/CDP4DiagramEditor.Tests/CDP4DiagramEditor.Tests.csproj
+++ b/CDP4DiagramEditor.Tests/CDP4DiagramEditor.Tests.csproj
@@ -64,5 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
 </Project>

--- a/CDP4DiagramEditor.Tests/Helpers/RelationshipGraphBuilderTestFixture.cs
+++ b/CDP4DiagramEditor.Tests/Helpers/RelationshipGraphBuilderTestFixture.cs
@@ -245,24 +245,6 @@ namespace CDP4DiagramEditor.Tests.Helpers
         }
 
         [Test]
-        public void VerifyThatTheNodeFilterIsApplied()
-        {
-            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
-            this.AddBinaryRelationship(this.spec1, this.elementDefinition, this.traceCategory);
-
-            var builder = new RelationshipGraphBuilder(this.iteration);
-
-            var configuration = new RelationshipGraphConfiguration { DepthDown = 1, DepthUp = 0 };
-            configuration.NodeFilter = new RelationshipGraphFilter();
-            configuration.NodeFilter.ClassKinds.Add(ClassKind.RequirementsSpecification);
-
-            var graph = builder.Build(new[] { this.spec1 }, configuration);
-
-            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
-            Assert.That(graph.Edges.Count, Is.EqualTo(1));
-        }
-
-        [Test]
         public void VerifyThatAMultiRelationshipExpandsToAllRelatedThingsAndCostsOneLevel()
         {
             this.AddMultiRelationship(this.spec1, this.spec2, this.spec3);

--- a/CDP4DiagramEditor.Tests/Helpers/RelationshipGraphBuilderTestFixture.cs
+++ b/CDP4DiagramEditor.Tests/Helpers/RelationshipGraphBuilderTestFixture.cs
@@ -1,0 +1,433 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipGraphBuilderTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Tests.Helpers
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Dal;
+
+    using CDP4DiagramEditor.Helpers;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="RelationshipGraphBuilder"/> class
+    /// </summary>
+    [TestFixture]
+    public class RelationshipGraphBuilderTestFixture
+    {
+        private readonly Uri uri = new Uri("http://test.com");
+        private ConcurrentDictionary<CacheKey, Lazy<Thing>> cache;
+        private Iteration iteration;
+
+        private Category traceCategory;
+        private Category otherCategory;
+
+        private RequirementsSpecification spec1;
+        private RequirementsSpecification spec2;
+        private RequirementsSpecification spec3;
+        private RequirementsSpecification spec4;
+        private ElementDefinition elementDefinition;
+
+        [SetUp]
+        public void Setup()
+        {
+            var messageBus = new CDPMessageBus();
+            var assembler = new Assembler(this.uri, messageBus);
+            this.cache = assembler.Cache;
+
+            this.iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri);
+
+            this.traceCategory = new Category(Guid.NewGuid(), this.cache, this.uri) { ShortName = "trace" };
+            this.otherCategory = new Category(Guid.NewGuid(), this.cache, this.uri) { ShortName = "other" };
+
+            this.spec1 = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { ShortName = "spec1" };
+            this.spec2 = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { ShortName = "spec2" };
+            this.spec3 = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { ShortName = "spec3" };
+            this.spec4 = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { ShortName = "spec4" };
+            this.elementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { ShortName = "ed" };
+
+            this.iteration.RequirementsSpecification.Add(this.spec1);
+            this.iteration.RequirementsSpecification.Add(this.spec2);
+            this.iteration.RequirementsSpecification.Add(this.spec3);
+            this.iteration.RequirementsSpecification.Add(this.spec4);
+            this.iteration.Element.Add(this.elementDefinition);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="BinaryRelationship"/> to the <see cref="Iteration"/> under test
+        /// </summary>
+        /// <param name="source">The source <see cref="Thing"/></param>
+        /// <param name="target">The target <see cref="Thing"/></param>
+        /// <param name="categories">The <see cref="Category"/>s of the relationship</param>
+        /// <returns>The created <see cref="BinaryRelationship"/></returns>
+        private BinaryRelationship AddBinaryRelationship(Thing source, Thing target, params Category[] categories)
+        {
+            var relationship = new BinaryRelationship(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Source = source,
+                Target = target
+            };
+
+            relationship.Category.AddRange(categories);
+            this.iteration.Relationship.Add(relationship);
+
+            return relationship;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="MultiRelationship"/> to the <see cref="Iteration"/> under test
+        /// </summary>
+        /// <param name="relatedThings">The related <see cref="Thing"/>s</param>
+        /// <returns>The created <see cref="MultiRelationship"/></returns>
+        private MultiRelationship AddMultiRelationship(params Thing[] relatedThings)
+        {
+            var relationship = new MultiRelationship(Guid.NewGuid(), this.cache, this.uri);
+
+            relationship.RelatedThing.AddRange(relatedThings);
+            this.iteration.Relationship.Add(relationship);
+
+            return relationship;
+        }
+
+        [Test]
+        public void VerifyThatDownwardDepthIsHonoured()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+            this.AddBinaryRelationship(this.spec3, this.spec4, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 2, DepthUp = 0 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+            Assert.That(graph.Edges.Count, Is.EqualTo(2));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec1).Level, Is.EqualTo(0));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec2).Level, Is.EqualTo(1));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec3).Level, Is.EqualTo(2));
+            Assert.That(graph.MaxNodeCountReached, Is.False);
+        }
+
+        [Test]
+        public void VerifyThatUpwardDepthIsHonoured()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 0, DepthUp = 1 };
+
+            var graph = builder.Build(new[] { this.spec3 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec2, this.spec3 }));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec2).Level, Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void VerifyThatUpwardAndDownwardTraversalAreIndependent()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+            this.AddBinaryRelationship(this.spec3, this.spec4, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 1, DepthUp = 1 };
+
+            var graph = builder.Build(new[] { this.spec2 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec1).Level, Is.EqualTo(-1));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec3).Level, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void VerifyThatBinaryRelationshipEdgeKeepsItsDirectionWhenTraversedUpward()
+        {
+            var relationship = this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 0, DepthUp = 1 };
+
+            var graph = builder.Build(new[] { this.spec2 }, configuration);
+
+            var edge = graph.Edges.Single();
+
+            Assert.That(edge.Relationship, Is.EqualTo(relationship));
+            Assert.That(edge.Source, Is.EqualTo(this.spec1));
+            Assert.That(edge.Target, Is.EqualTo(this.spec2));
+        }
+
+        [Test]
+        public void VerifyThatTheDefaultLevelFilterIsApplied()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec1, this.spec3, this.otherCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 1, DepthUp = 0 };
+            configuration.DefaultLevelFilter = new RelationshipGraphFilter();
+            configuration.DefaultLevelFilter.Categories.Add(this.traceCategory);
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
+        }
+
+        [Test]
+        public void VerifyThatALevelFilterOverrideIsApplied()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 2, DepthUp = 0 };
+
+            var levelTwoFilter = new RelationshipGraphFilter();
+            levelTwoFilter.Categories.Add(this.otherCategory);
+            configuration.LevelFilterOverrides.Add(2, levelTwoFilter);
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
+        }
+
+        [Test]
+        public void VerifyThatALevelFilterMatchesASubCategory()
+        {
+            var subCategory = new Category(Guid.NewGuid(), this.cache, this.uri) { ShortName = "subtrace" };
+            subCategory.SuperCategory.Add(this.traceCategory);
+
+            this.AddBinaryRelationship(this.spec1, this.spec2, subCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 1, DepthUp = 0 };
+            configuration.DefaultLevelFilter = new RelationshipGraphFilter();
+            configuration.DefaultLevelFilter.Categories.Add(this.traceCategory);
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
+        }
+
+        [Test]
+        public void VerifyThatTheNodeFilterIsApplied()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec1, this.elementDefinition, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 1, DepthUp = 0 };
+            configuration.NodeFilter = new RelationshipGraphFilter();
+            configuration.NodeFilter.ClassKinds.Add(ClassKind.RequirementsSpecification);
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
+            Assert.That(graph.Edges.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void VerifyThatAMultiRelationshipExpandsToAllRelatedThingsAndCostsOneLevel()
+        {
+            this.AddMultiRelationship(this.spec1, this.spec2, this.spec3);
+            this.AddBinaryRelationship(this.spec3, this.spec4, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 1, DepthUp = 0 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec2).Level, Is.EqualTo(1));
+            Assert.That(graph.Edges.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void VerifyThatAMultiRelationshipEdgeIsNotDuplicatedWhenBothEndpointsExpand()
+        {
+            this.AddMultiRelationship(this.spec1, this.spec2);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 3, DepthUp = 0 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            // expanding spec2 finds the same relationship back to spec1; that must not add a second edge
+            Assert.That(graph.Edges.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void VerifyThatAMultiRelationshipIsExpandedInBothDirections()
+        {
+            this.AddMultiRelationship(this.spec1, this.spec2);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 0, DepthUp = 1 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec2).Level, Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void VerifyThatACycleTerminates()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+            this.AddBinaryRelationship(this.spec3, this.spec1, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 100, DepthUp = 100 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+            Assert.That(graph.Edges.Count, Is.EqualTo(3));
+            Assert.That(graph.MaxNodeCountReached, Is.False);
+        }
+
+        [Test]
+        public void VerifyThatTheMaxNodeCountGuardTrips()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+            this.AddBinaryRelationship(this.spec3, this.spec4, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 10, DepthUp = 0, MaxNodes = 2 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.MaxNodeCountReached, Is.True);
+            Assert.That(graph.Nodes.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void VerifyThatALevelDirectionOverrideFollowsArrowsBackwards()
+        {
+            // requirement decomposition points downward, but the equipment link points up: spec4 -> spec3
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+            this.AddBinaryRelationship(this.spec4, this.spec3, this.otherCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 3, DepthUp = 0 };
+
+            // without the override the third hop finds nothing
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+
+            var levelThreeFilter = new RelationshipGraphFilter { Direction = RelationshipTraversalDirection.AgainstArrows };
+            configuration.LevelFilterOverrides.Add(3, levelThreeFilter);
+
+            graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3, this.spec4 }));
+            Assert.That(graph.Nodes.Single(x => x.Thing == this.spec4).Level, Is.EqualTo(3));
+
+            // the rendered edge keeps the true arrow of the model
+            var equipmentEdge = graph.Edges.Single(x => x.Source == this.spec4);
+            Assert.That(equipmentEdge.Target, Is.EqualTo(this.spec3));
+        }
+
+        [Test]
+        public void VerifyThatTheBothDirectionFollowsArrowsBothWays()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec3, this.spec1, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 1, DepthUp = 0 };
+            configuration.DefaultLevelFilter = new RelationshipGraphFilter { Direction = RelationshipTraversalDirection.Both };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+        }
+
+        [Test]
+        public void VerifyThatExplicitlyExcludedThingsArePrunedWithTheirSubtree()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 5, DepthUp = 0 };
+            configuration.ExcludedThings.Add(this.spec2.Iid);
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1 }));
+            Assert.That(graph.Edges, Is.Empty);
+
+            // an excluded root is not added either
+            graph = builder.Build(new[] { this.spec2 }, configuration);
+            Assert.That(graph.Nodes, Is.Empty);
+        }
+
+        [Test]
+        public void VerifyThatDeprecatedThingsAreExcluded()
+        {
+            this.spec2.IsDeprecated = true;
+
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 5, DepthUp = 0 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1 }));
+            Assert.That(graph.Edges, Is.Empty);
+        }
+
+        [Test]
+        public void VerifyThatBuildThrowsOnNullArguments()
+        {
+            var builder = new RelationshipGraphBuilder(this.iteration);
+
+            Assert.Throws<ArgumentNullException>(() => new RelationshipGraphBuilder(null));
+            Assert.Throws<ArgumentNullException>(() => builder.Build(null, new RelationshipGraphConfiguration()));
+            Assert.Throws<ArgumentNullException>(() => builder.Build(new[] { this.spec1 }, null));
+        }
+    }
+}

--- a/CDP4DiagramEditor.Tests/Helpers/RelationshipGraphBuilderTestFixture.cs
+++ b/CDP4DiagramEditor.Tests/Helpers/RelationshipGraphBuilderTestFixture.cs
@@ -404,6 +404,42 @@ namespace CDP4DiagramEditor.Tests.Helpers
         }
 
         [Test]
+        public void VerifyThatADeprecatedRootIsExcluded()
+        {
+            this.spec1.IsDeprecated = true;
+
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 5, DepthUp = 0 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.Nodes, Is.Empty);
+            Assert.That(graph.Edges, Is.Empty);
+        }
+
+        [Test]
+        public void VerifyThatTraversalStopsAtTheLevelWhereTheNodeCapTrips()
+        {
+            // a chain that is far deeper than the cap allows
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+            this.AddBinaryRelationship(this.spec3, this.spec4, this.traceCategory);
+
+            var builder = new RelationshipGraphBuilder(this.iteration);
+            var configuration = new RelationshipGraphConfiguration { DepthDown = 20, DepthUp = 0, MaxNodes = 2 };
+
+            var graph = builder.Build(new[] { this.spec1 }, configuration);
+
+            Assert.That(graph.MaxNodeCountReached, Is.True);
+            Assert.That(graph.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
+
+            // nothing beyond the capped level was reached, so no node carries a deeper level
+            Assert.That(graph.Nodes.Max(x => x.Level), Is.EqualTo(1));
+        }
+
+        [Test]
         public void VerifyThatDeprecatedThingsAreExcluded()
         {
             this.spec2.IsDeprecated = true;

--- a/CDP4DiagramEditor.Tests/ViewModels/RelationshipTraceabilityViewModelTestFixture.cs
+++ b/CDP4DiagramEditor.Tests/ViewModels/RelationshipTraceabilityViewModelTestFixture.cs
@@ -479,6 +479,66 @@ namespace CDP4DiagramEditor.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatTheUpwardConeIsLaidOutAboveTheRoot()
+        {
+            // spec3 -> spec2 -> spec1, so from spec1 the chain runs upward: spec2 at -1, spec3 at -2
+            var toRoot = this.AddBinaryRelationship(this.spec2, this.spec1, this.traceCategory);
+            var toAncestor = this.AddBinaryRelationship(this.spec3, this.spec2, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.DepthDown = 0;
+            viewModel.DepthUp = 2;
+
+            Assert.That(viewModel.Nodes.Single(x => x.Thing == this.spec2).Level, Is.EqualTo(-1));
+            Assert.That(viewModel.Nodes.Single(x => x.Thing == this.spec3).Level, Is.EqualTo(-2));
+
+            // every connector runs from the higher to the lower node, so the ancestors stack above the root
+            var rootEdge = viewModel.Edges.Single(x => x.Relationship == toRoot);
+            Assert.That(rootEdge.FromId, Is.EqualTo(this.spec2.Iid));
+            Assert.That(rootEdge.ToId, Is.EqualTo(this.spec1.Iid));
+
+            var ancestorEdge = viewModel.Edges.Single(x => x.Relationship == toAncestor);
+            Assert.That(ancestorEdge.FromId, Is.EqualTo(this.spec3.Iid));
+            Assert.That(ancestorEdge.ToId, Is.EqualTo(this.spec2.Iid));
+
+            // both keep the model arrow, so neither is drawn reversed
+            Assert.That(rootEdge.IsReversed, Is.False);
+            Assert.That(ancestorEdge.IsReversed, Is.False);
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatTheUpwardAndDownwardConesAreLaidOutOnOppositeSidesOfTheRoot()
+        {
+            // spec2 -> spec1 -> spec3, so spec2 is an ancestor and spec3 a descendant of the root
+            this.AddBinaryRelationship(this.spec2, this.spec1, this.traceCategory);
+            this.AddBinaryRelationship(this.spec1, this.spec3, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.DepthDown = 1;
+            viewModel.DepthUp = 1;
+
+            var levels = viewModel.Nodes.ToDictionary(x => x.Thing, x => x.Level);
+
+            Assert.That(levels[this.spec2], Is.LessThan(levels[this.spec1]));
+            Assert.That(levels[this.spec3], Is.GreaterThan(levels[this.spec1]));
+
+            // the connectors follow that same order, which is what the layout ranks on
+            foreach (var edge in viewModel.Edges)
+            {
+                var from = viewModel.Nodes.Single(x => x.Id == edge.FromId).Level;
+                var to = viewModel.Nodes.Single(x => x.Id == edge.ToId).Level;
+
+                Assert.That(from, Is.LessThanOrEqualTo(to));
+            }
+
+            viewModel.Dispose();
+        }
+
+        [Test]
         public void VerifyThatTheDefaultDirectionIsApplied()
         {
             // both arrows point at spec1, so the natural downward expansion finds nothing

--- a/CDP4DiagramEditor.Tests/ViewModels/RelationshipTraceabilityViewModelTestFixture.cs
+++ b/CDP4DiagramEditor.Tests/ViewModels/RelationshipTraceabilityViewModelTestFixture.cs
@@ -1,0 +1,592 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipTraceabilityViewModelTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Tests.ViewModels
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reactive.Concurrency;
+    using System.Reactive.Linq;
+    using System.Threading.Tasks;
+    using System.Windows;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Composition.DragDrop;
+    using CDP4Composition.Exceptions;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Events;
+    using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.PluginSettingService;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+    using CDP4Dal.Permission;
+
+    using CDP4DiagramEditor.Behaviors;
+    using CDP4DiagramEditor.Helpers;
+    using CDP4DiagramEditor.Settings;
+    using CDP4DiagramEditor.ViewModels;
+
+    using DevExpress.Diagram.Core;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="RelationshipTraceabilityViewModel"/> class
+    /// </summary>
+    [TestFixture]
+    public class RelationshipTraceabilityViewModelTestFixture
+    {
+        private Mock<ISession> session;
+        private Mock<IPermissionService> permissionService;
+        private Mock<IThingDialogNavigationService> thingDialogNavigationService;
+        private Mock<IPanelNavigationService> panelNavigationService;
+        private Mock<IPluginSettingsService> pluginSettingsService;
+        private readonly Uri uri = new Uri("http://test.com");
+        private CDPMessageBus messageBus;
+        private Assembler assembler;
+        private ConcurrentDictionary<CacheKey, Lazy<Thing>> cache;
+
+        private SiteDirectory sitedir;
+        private SiteReferenceDataLibrary srdl;
+        private EngineeringModelSetup modelsetup;
+        private IterationSetup iterationsetup;
+        private Person person;
+        private Participant participant;
+        private EngineeringModel model;
+        private Iteration iteration;
+        private DomainOfExpertise domain;
+
+        private Category specCategory;
+        private Category traceCategory;
+        private Category otherCategory;
+
+        private RequirementsSpecification spec1;
+        private RequirementsSpecification spec2;
+        private RequirementsSpecification spec3;
+        private ElementDefinition elementDefinition;
+
+        private DiagramEditorPluginSettings settings;
+
+        [SetUp]
+        public void Setup()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.messageBus = new CDPMessageBus();
+            this.session = new Mock<ISession>();
+            this.assembler = new Assembler(this.uri, this.messageBus);
+            this.cache = this.assembler.Cache;
+            this.permissionService = new Mock<IPermissionService>();
+            this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();
+            this.panelNavigationService = new Mock<IPanelNavigationService>();
+            this.pluginSettingsService = new Mock<IPluginSettingsService>();
+
+            this.sitedir = new SiteDirectory(Guid.NewGuid(), this.cache, this.uri);
+            this.srdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri);
+            this.modelsetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri) { Name = "model" };
+            this.iterationsetup = new IterationSetup(Guid.NewGuid(), this.cache, this.uri);
+            this.person = new Person(Guid.NewGuid(), this.cache, this.uri);
+            this.domain = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "domain" };
+            this.participant = new Participant(Guid.NewGuid(), this.cache, this.uri) { Person = this.person, SelectedDomain = this.domain };
+
+            this.sitedir.Model.Add(this.modelsetup);
+            this.sitedir.SiteReferenceDataLibrary.Add(this.srdl);
+            this.sitedir.Person.Add(this.person);
+            this.sitedir.Domain.Add(this.domain);
+            this.modelsetup.IterationSetup.Add(this.iterationsetup);
+            this.modelsetup.Participant.Add(this.participant);
+
+            this.model = new EngineeringModel(Guid.NewGuid(), this.cache, this.uri) { EngineeringModelSetup = this.modelsetup };
+            this.iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri) { IterationSetup = this.iterationsetup };
+            this.model.Iteration.Add(this.iteration);
+
+            this.specCategory = new Category(Guid.NewGuid(), this.cache, this.uri) { Name = "spec", ShortName = "spec" };
+            this.specCategory.PermissibleClass.Add(ClassKind.RequirementsSpecification);
+
+            this.traceCategory = new Category(Guid.NewGuid(), this.cache, this.uri) { Name = "trace", ShortName = "trace" };
+            this.traceCategory.PermissibleClass.Add(ClassKind.BinaryRelationship);
+
+            this.otherCategory = new Category(Guid.NewGuid(), this.cache, this.uri) { Name = "other", ShortName = "other" };
+            this.otherCategory.PermissibleClass.Add(ClassKind.BinaryRelationship);
+            this.otherCategory.PermissibleClass.Add(ClassKind.ElementDefinition);
+            this.srdl.DefinedCategory.Add(this.specCategory);
+            this.srdl.DefinedCategory.Add(this.traceCategory);
+            this.srdl.DefinedCategory.Add(this.otherCategory);
+
+            this.spec1 = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { ShortName = "spec1" };
+            this.spec2 = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { ShortName = "spec2" };
+            this.spec3 = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { ShortName = "spec3" };
+            this.elementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { ShortName = "ed" };
+
+            this.spec1.Category.Add(this.specCategory);
+            this.spec2.Category.Add(this.specCategory);
+
+            this.iteration.RequirementsSpecification.Add(this.spec1);
+            this.iteration.RequirementsSpecification.Add(this.spec2);
+            this.iteration.RequirementsSpecification.Add(this.spec3);
+            this.iteration.Element.Add(this.elementDefinition);
+
+            this.AddToCache(this.iteration);
+            this.AddToCache(this.spec1);
+            this.AddToCache(this.spec2);
+            this.AddToCache(this.spec3);
+            this.AddToCache(this.elementDefinition);
+
+            this.settings = new DiagramEditorPluginSettings();
+            this.pluginSettingsService.Setup(x => x.Read<DiagramEditorPluginSettings>(false)).Returns(this.settings);
+
+            this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.sitedir);
+            this.session.Setup(x => x.ActivePerson).Returns(this.person);
+            this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+            this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>());
+            this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+            this.session.Setup(x => x.Assembler).Returns(this.assembler);
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new List<ReferenceDataLibrary> { this.srdl });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.messageBus.ClearSubscriptions();
+        }
+
+        /// <summary>
+        /// Adds a <see cref="Thing"/> to the assembler cache under the iteration under test
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to add</param>
+        private void AddToCache(Thing thing)
+        {
+            this.cache.TryAdd(new CacheKey(thing.Iid, this.iteration.Iid), new Lazy<Thing>(() => thing));
+        }
+
+        /// <summary>
+        /// Adds a <see cref="BinaryRelationship"/> to the <see cref="Iteration"/> under test
+        /// </summary>
+        /// <param name="source">The source <see cref="Thing"/></param>
+        /// <param name="target">The target <see cref="Thing"/></param>
+        /// <param name="categories">The <see cref="Category"/>s of the relationship</param>
+        /// <returns>The created <see cref="BinaryRelationship"/></returns>
+        private BinaryRelationship AddBinaryRelationship(Thing source, Thing target, params Category[] categories)
+        {
+            var relationship = new BinaryRelationship(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Source = source,
+                Target = target
+            };
+
+            relationship.Category.AddRange(categories);
+            this.iteration.Relationship.Add(relationship);
+
+            return relationship;
+        }
+
+        /// <summary>
+        /// Creates the <see cref="RelationshipTraceabilityViewModel"/> under test
+        /// </summary>
+        /// <returns>The created <see cref="RelationshipTraceabilityViewModel"/></returns>
+        private RelationshipTraceabilityViewModel CreateViewModel()
+        {
+            return new RelationshipTraceabilityViewModel(
+                this.iteration,
+                this.session.Object,
+                this.thingDialogNavigationService.Object,
+                this.panelNavigationService.Object,
+                null,
+                this.pluginSettingsService.Object);
+        }
+
+        [Test]
+        public void VerifyThatAMissingSettingsFileIsCreatedOnFirstUse()
+        {
+            this.pluginSettingsService
+                .Setup(x => x.Read<DiagramEditorPluginSettings>(false))
+                .Throws(new PluginSettingsException("The PluginSettings could not be read", new System.IO.FileNotFoundException()));
+
+            RelationshipTraceabilityViewModel viewModel = null;
+            Assert.DoesNotThrow(() => viewModel = this.CreateViewModel());
+
+            Assert.That(viewModel.SavedConfigurations, Is.Empty);
+            this.pluginSettingsService.Verify(x => x.Write(It.IsAny<DiagramEditorPluginSettings>()), Times.Once);
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatPanelInitializesEmpty()
+        {
+            var viewModel = this.CreateViewModel();
+
+            Assert.That(viewModel.Caption, Is.Not.Null.Or.Empty);
+            Assert.That(viewModel.ToolTip, Is.Not.Null.Or.Empty);
+            Assert.That(viewModel.Nodes, Is.Empty);
+            Assert.That(viewModel.Edges, Is.Empty);
+
+            // only categories permissible on the offered class kinds are shown
+            Assert.That(viewModel.PossibleCategories, Is.EquivalentTo(new[] { this.specCategory, this.otherCategory }));
+            Assert.That(viewModel.PossibleRelationshipCategories, Is.EquivalentTo(new[] { this.traceCategory, this.otherCategory }));
+
+            // the curated class kind set, not every categorizable class kind of the model
+            Assert.That(viewModel.PossibleClassKinds, Does.Contain(ClassKind.RequirementsSpecification));
+            Assert.That(viewModel.PossibleClassKinds, Does.Not.Contain(ClassKind.Glossary));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatPossibleCategoriesFollowTheSelectedRootClassKinds()
+        {
+            var viewModel = this.CreateViewModel();
+
+            viewModel.SelectedRootClassKinds = new List<ClassKind> { ClassKind.RequirementsSpecification };
+            Assert.That(viewModel.PossibleCategories, Is.EquivalentTo(new[] { this.specCategory }));
+
+            viewModel.SelectedRootClassKinds = new List<ClassKind> { ClassKind.ElementDefinition };
+            Assert.That(viewModel.PossibleCategories, Is.EquivalentTo(new[] { this.otherCategory }));
+
+            viewModel.SelectedRootClassKinds = new List<ClassKind>();
+            Assert.That(viewModel.PossibleCategories, Is.EquivalentTo(new[] { this.specCategory, this.otherCategory }));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyThatDroppingAThingAddsARootAndComputesTheGraph()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+
+            var dropInfo = new Mock<IDropInfo>();
+            dropInfo.Setup(x => x.Payload).Returns(this.spec1);
+            dropInfo.SetupProperty(x => x.Effects);
+
+            viewModel.DragOver(dropInfo.Object);
+            Assert.That(dropInfo.Object.Effects, Is.EqualTo(DragDropEffects.Copy));
+
+            await viewModel.Drop(dropInfo.Object);
+
+            // default configuration: two levels down
+            Assert.That(viewModel.RootThings, Is.EquivalentTo(new Thing[] { this.spec1 }));
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+            Assert.That(viewModel.Edges.Count, Is.EqualTo(2));
+            Assert.That(viewModel.StatusMessage, Does.Contain("3 nodes"));
+
+            // dropping the same thing again is refused
+            viewModel.DragOver(dropInfo.Object);
+            Assert.That(dropInfo.Object.Effects, Is.EqualTo(DragDropEffects.None));
+
+            // a thing that does not belong to this iteration is refused
+            var foreignThing = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri);
+            dropInfo.Setup(x => x.Payload).Returns(foreignThing);
+
+            viewModel.DragOver(dropInfo.Object);
+            Assert.That(dropInfo.Object.Effects, Is.EqualTo(DragDropEffects.None));
+
+            await viewModel.Drop(dropInfo.Object);
+            Assert.That(viewModel.RootThings, Does.Not.Contain(foreignThing));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatClassKindAndCategoryRootsAreComputed()
+        {
+            this.AddBinaryRelationship(this.spec1, this.elementDefinition, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+
+            viewModel.SelectedRootClassKinds = new List<ClassKind> { ClassKind.RequirementsSpecification };
+
+            // spec1..spec3 are roots, spec1 reaches the element definition
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3, this.elementDefinition }));
+
+            viewModel.SelectedRootCategories = new List<Category> { this.specCategory };
+
+            // only spec1 and spec2 carry the spec category
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.elementDefinition }));
+
+            // multiple class kinds combine: the uncategorized element definition becomes a root through its own kind
+            viewModel.SelectedRootCategories = new List<Category>();
+            viewModel.SelectedRootClassKinds = new List<ClassKind> { ClassKind.RequirementsSpecification, ClassKind.ElementDefinition };
+
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3, this.elementDefinition }));
+            Assert.That(viewModel.Nodes.Single(x => x.Thing == this.elementDefinition).IsRoot, Is.True);
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyThatExcludingANodeRemovesItAndItsSubtree()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.ComputeGraph();
+
+            Assert.That(viewModel.Nodes.Count, Is.EqualTo(3));
+
+            viewModel.SelectedNode = viewModel.Nodes.Single(x => x.Thing == this.spec2);
+            await viewModel.ExcludeSelectedNodeCommand.Execute();
+
+            // spec3 was only reachable through spec2, so it disappears with it
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1 }));
+            Assert.That(viewModel.StatusMessage, Does.Contain("1 excluded"));
+            Assert.That(viewModel.SelectedNode, Is.Null);
+
+            // the exclusion is listed and can be restored individually
+            Assert.That(viewModel.ExcludedThings, Is.EquivalentTo(new Thing[] { this.spec2 }));
+
+            viewModel.SelectedExcludedThing = this.spec2;
+            await viewModel.RestoreExcludedThingCommand.Execute();
+
+            Assert.That(viewModel.Nodes.Count, Is.EqualTo(3));
+            Assert.That(viewModel.ExcludedThings, Is.Empty);
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyThatEdgesRunInLevelOrderAndMarkReversedArrows()
+        {
+            // spec1 -> spec2 along the arrows, spec3 -> spec2 against them (reached at level 2)
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec3, this.spec2, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+
+            await viewModel.AddLevelFilterRowCommand.Execute();
+            var row = viewModel.LevelFilterRows.Single();
+            row.Level = 2;
+            row.SelectedDirection = TraceabilityDirectionOption.All.Single(x => x.Direction == RelationshipTraversalDirection.AgainstArrows);
+
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+
+            var alongEdge = viewModel.Edges.Single(x => x.FromId == this.spec1.Iid);
+            Assert.That(alongEdge.ToId, Is.EqualTo(this.spec2.Iid));
+            Assert.That(alongEdge.IsReversed, Is.False);
+
+            // the reversed link is laid out level 1 -> level 2 but flagged so the arrow is drawn backwards
+            var reversedEdge = viewModel.Edges.Single(x => x.ToId == this.spec3.Iid);
+            Assert.That(reversedEdge.FromId, Is.EqualTo(this.spec2.Iid));
+            Assert.That(reversedEdge.IsReversed, Is.True);
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatTheDefaultDirectionIsApplied()
+        {
+            // both arrows point at spec1, so the natural downward expansion finds nothing
+            this.AddBinaryRelationship(this.spec2, this.spec1, this.traceCategory);
+            this.AddBinaryRelationship(this.spec3, this.spec2, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.ComputeGraph();
+
+            Assert.That(viewModel.Nodes.Count, Is.EqualTo(1));
+
+            viewModel.SelectedDefaultDirection = viewModel.PossibleDirections.First(x => x.Direction == RelationshipTraversalDirection.AgainstArrows);
+
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyThatLayoutDirectionAndExportAreForwardedToTheBehavior()
+        {
+            var behavior = new Mock<ITraceabilityDiagramBehavior>();
+
+            var viewModel = this.CreateViewModel();
+            viewModel.Behavior = behavior.Object;
+
+            viewModel.LayoutDirection = Direction.Up;
+            behavior.Verify(x => x.ApplyLayout(), Times.Once);
+
+            await viewModel.ExportCommand.Execute("SVG");
+            behavior.Verify(x => x.Export(DiagramExportFormat.SVG), Times.Once);
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatTheDefaultLevelFilterIsApplied()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec1, this.spec3, this.otherCategory);
+
+            var viewModel = this.CreateViewModel();
+
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.SelectedDefaultLevelCategories = new List<Category> { this.traceCategory };
+
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyThatALevelFilterOverrideRowIsApplied()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+
+            await viewModel.AddLevelFilterRowCommand.Execute();
+            var row = viewModel.LevelFilterRows.Single();
+
+            row.Level = 2;
+            row.SelectedCategories = new List<Category> { this.otherCategory };
+
+            // level two only follows the other category, so spec3 is no longer reached
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2 }));
+
+            viewModel.SelectedLevelFilterRow = row;
+            await viewModel.RemoveLevelFilterRowCommand.Execute();
+
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatTheMaxNodeWarningTrips()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+            this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.MaxNodes = 2;
+
+            Assert.That(viewModel.IsMaxNodeCountReached, Is.True);
+            Assert.That(viewModel.Nodes.Count, Is.EqualTo(2));
+
+            viewModel.MaxNodes = 300;
+
+            Assert.That(viewModel.IsMaxNodeCountReached, Is.False);
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatARelationshipChangeRecomputesTheGraph()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.ComputeGraph();
+
+            Assert.That(viewModel.Nodes.Count, Is.EqualTo(2));
+
+            var newRelationship = this.AddBinaryRelationship(this.spec2, this.spec3, this.traceCategory);
+            this.messageBus.SendObjectChangeEvent(newRelationship, EventKind.Added);
+
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1, this.spec2, this.spec3 }));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyThatAConfigurationCanBeSavedAppliedAndDeleted()
+        {
+            var viewModel = this.CreateViewModel();
+
+            viewModel.DepthDown = 3;
+            viewModel.DepthUp = 1;
+            viewModel.SelectedDefaultLevelCategories = new List<Category> { this.traceCategory };
+            viewModel.SelectedRootClassKinds = new List<ClassKind> { ClassKind.RequirementsSpecification, ClassKind.ElementDefinition };
+            viewModel.SelectedRootCategories = new List<Category> { this.specCategory };
+            viewModel.ConfigurationName = "my preset";
+
+            await viewModel.SaveConfigurationCommand.Execute();
+
+            this.pluginSettingsService.Verify(x => x.Write(this.settings), Times.Once);
+            Assert.That(this.settings.SavedConfigurations.OfType<TraceabilityConfiguration>().Single().Name, Is.EqualTo("my preset"));
+            Assert.That(viewModel.SavedConfigurations.Count, Is.EqualTo(1));
+            Assert.That(viewModel.SelectedConfiguration, Is.Not.Null);
+
+            // change the state away from the preset, then re-apply it
+            viewModel.DepthDown = 1;
+            viewModel.SelectedDefaultLevelCategories = new List<Category>();
+
+            viewModel.SelectedConfiguration = null;
+            viewModel.SelectedConfiguration = viewModel.SavedConfigurations.Single();
+
+            Assert.That(viewModel.DepthDown, Is.EqualTo(3));
+            Assert.That(viewModel.DepthUp, Is.EqualTo(1));
+            Assert.That(viewModel.SelectedDefaultLevelCategories, Is.EquivalentTo(new[] { this.traceCategory }));
+            Assert.That(viewModel.SelectedRootClassKinds, Is.EquivalentTo(new[] { ClassKind.RequirementsSpecification, ClassKind.ElementDefinition }));
+            Assert.That(viewModel.SelectedRootCategories, Is.EquivalentTo(new[] { this.specCategory }));
+
+            await viewModel.DeleteConfigurationCommand.Execute();
+
+            Assert.That(this.settings.SavedConfigurations, Is.Empty);
+            Assert.That(viewModel.SavedConfigurations, Is.Empty);
+            Assert.That(viewModel.SelectedConfiguration, Is.Null);
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyThatSavingUnderAnExistingNameReplacesThePreset()
+        {
+            var viewModel = this.CreateViewModel();
+
+            viewModel.ConfigurationName = "preset";
+            viewModel.DepthDown = 2;
+            await viewModel.SaveConfigurationCommand.Execute();
+
+            viewModel.DepthDown = 5;
+            await viewModel.SaveConfigurationCommand.Execute();
+
+            var saved = this.settings.SavedConfigurations.OfType<TraceabilityConfiguration>().Single();
+            Assert.That(saved.DepthDown, Is.EqualTo(5));
+
+            viewModel.Dispose();
+        }
+    }
+}

--- a/CDP4DiagramEditor.Tests/ViewModels/RelationshipTraceabilityViewModelTestFixture.cs
+++ b/CDP4DiagramEditor.Tests/ViewModels/RelationshipTraceabilityViewModelTestFixture.cs
@@ -412,6 +412,73 @@ namespace CDP4DiagramEditor.Tests.ViewModels
         }
 
         [Test]
+        public async Task VerifyThatDroppingAnExcludedThingLiftsTheExclusion()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.ComputeGraph();
+
+            viewModel.SelectedNode = viewModel.Nodes.Single(x => x.Thing == this.spec2);
+            await viewModel.ExcludeSelectedNodeCommand.Execute();
+
+            Assert.That(viewModel.ExcludedThings, Is.EquivalentTo(new Thing[] { this.spec2 }));
+
+            var dropInfo = new Mock<IDropInfo>();
+            dropInfo.Setup(x => x.Payload).Returns(this.spec2);
+            dropInfo.SetupProperty(x => x.Effects);
+
+            viewModel.DragOver(dropInfo.Object);
+            Assert.That(dropInfo.Object.Effects, Is.EqualTo(DragDropEffects.Copy));
+
+            await viewModel.Drop(dropInfo.Object);
+
+            // the accepted drop actually shows the thing instead of being swallowed by the exclusion
+            Assert.That(viewModel.ExcludedThings, Is.Empty);
+            Assert.That(viewModel.RootThings, Does.Contain(this.spec2));
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Does.Contain(this.spec2));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatDeprecatingADisplayedThingRefreshesTheDiagram()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.ComputeGraph();
+
+            Assert.That(viewModel.Nodes.Count, Is.EqualTo(2));
+
+            this.spec2.IsDeprecated = true;
+            this.messageBus.SendObjectChangeEvent(this.spec2, EventKind.Updated);
+
+            Assert.That(viewModel.Nodes.Select(x => x.Thing), Is.EquivalentTo(new Thing[] { this.spec1 }));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatRenamingADisplayedThingRefreshesTheDiagram()
+        {
+            this.AddBinaryRelationship(this.spec1, this.spec2, this.traceCategory);
+
+            var viewModel = this.CreateViewModel();
+            viewModel.RootThings.Add(this.spec1);
+            viewModel.ComputeGraph();
+
+            this.spec2.ShortName = "renamed";
+            this.messageBus.SendObjectChangeEvent(this.spec2, EventKind.Updated);
+
+            Assert.That(viewModel.Nodes.Single(x => x.Thing == this.spec2).ShortName, Is.EqualTo("renamed"));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
         public void VerifyThatTheDefaultDirectionIsApplied()
         {
             // both arrows point at spec1, so the natural downward expansion finds nothing

--- a/CDP4DiagramEditor.Tests/Views/RelationshipTraceabilityViewTestFixture.cs
+++ b/CDP4DiagramEditor.Tests/Views/RelationshipTraceabilityViewTestFixture.cs
@@ -1,0 +1,58 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipTraceabilityViewTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Tests.Views
+{
+    using System.Threading;
+    using System.Windows;
+
+    using CDP4DiagramEditor.Views;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="RelationshipTraceability"/> view. Loading the view headless catches XAML
+    /// errors that only surface at runtime, such as behaviors added to an incompatible behavior collection.
+    /// </summary>
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    public class RelationshipTraceabilityViewTestFixture
+    {
+        [Test]
+        public void VerifyThatTheViewLoadsAndMeasures()
+        {
+            RelationshipTraceability view = null;
+
+            Assert.DoesNotThrow(() => view = new RelationshipTraceability(true));
+
+            // deferred template content, such as the diagram behaviors, only loads on measure
+            Assert.DoesNotThrow(() =>
+            {
+                view.Measure(new Size(800, 600));
+                view.Arrange(new Rect(0, 0, 800, 600));
+            });
+        }
+    }
+}

--- a/CDP4DiagramEditor/Behaviors/ITraceabilityDiagramBehavior.cs
+++ b/CDP4DiagramEditor/Behaviors/ITraceabilityDiagramBehavior.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ITraceabilityDiagramBehavior.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Behaviors
+{
+    using DevExpress.Diagram.Core;
+
+    /// <summary>
+    /// Definition of the view side of the traceability diagram that the view-model drives: applying the automatic
+    /// layout and exporting the diagram to a file
+    /// </summary>
+    public interface ITraceabilityDiagramBehavior
+    {
+        /// <summary>
+        /// Applies the Sugiyama automatic layout in the orientation currently selected on the view-model and centers
+        /// the page
+        /// </summary>
+        void ApplyLayout();
+
+        /// <summary>
+        /// Exports the diagram to a file picked by the user
+        /// </summary>
+        /// <param name="format">The <see cref="DiagramExportFormat"/> to export to</param>
+        void Export(DiagramExportFormat format);
+    }
+}

--- a/CDP4DiagramEditor/Behaviors/TraceabilityDiagramBehavior.cs
+++ b/CDP4DiagramEditor/Behaviors/TraceabilityDiagramBehavior.cs
@@ -52,10 +52,10 @@ namespace CDP4DiagramEditor.Behaviors
     public class TraceabilityDiagramBehavior : Behavior<DiagramControl>, ITraceabilityDiagramBehavior
     {
         /// <summary>
-        /// A value indicating whether a layout pass is already scheduled, used to coalesce the per-item
-        /// <see cref="DiagramControl.ItemsChanged"/> events into a single layout pass
+        /// The scheduled layout pass, used both to coalesce the per-item <see cref="DiagramControl.ItemsChanged"/>
+        /// events into a single layout pass and to abort that pass when the behavior detaches
         /// </summary>
-        private bool layoutPending;
+        private DispatcherOperation layoutOperation;
 
         /// <summary>
         /// The on attached event handler
@@ -73,6 +73,10 @@ namespace CDP4DiagramEditor.Behaviors
         /// </summary>
         protected override void OnDetaching()
         {
+            // a layout pass queued by the last items change would run after the panel is gone
+            this.layoutOperation?.Abort();
+            this.layoutOperation = null;
+
             this.AssociatedObject.DataContextChanged -= this.OnDataContextChanged;
             this.AssociatedObject.ItemsChanged -= this.OnItemsChanged;
 
@@ -90,7 +94,7 @@ namespace CDP4DiagramEditor.Behaviors
         /// </summary>
         public void ApplyLayout()
         {
-            if (!this.AssociatedObject.Items.OfType<DiagramContentItem>().Any())
+            if (this.AssociatedObject == null || !this.AssociatedObject.Items.OfType<DiagramContentItem>().Any())
             {
                 return;
             }
@@ -237,17 +241,15 @@ namespace CDP4DiagramEditor.Behaviors
                 connector.EndArrow = edge.IsReversed || edge.IsUndirected ? null : ArrowDescriptions.Filled90;
             }
 
-            if (this.layoutPending)
+            if (this.layoutOperation != null)
             {
                 return;
             }
 
-            this.layoutPending = true;
-
-            this.AssociatedObject.Dispatcher.BeginInvoke(
+            this.layoutOperation = this.AssociatedObject.Dispatcher.BeginInvoke(
                 new Action(() =>
                 {
-                    this.layoutPending = false;
+                    this.layoutOperation = null;
                     this.ApplyLayout();
                 }),
                 DispatcherPriority.Background);

--- a/CDP4DiagramEditor/Behaviors/TraceabilityDiagramBehavior.cs
+++ b/CDP4DiagramEditor/Behaviors/TraceabilityDiagramBehavior.cs
@@ -1,0 +1,256 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityDiagramBehavior.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Behaviors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Security;
+    using System.Text;
+    using System.Windows;
+    using System.Windows.Threading;
+
+    using CDP4Composition.Navigation;
+
+    using CDP4DiagramEditor.ViewModels;
+
+    using CommonServiceLocator;
+
+    using DevExpress.Diagram.Core;
+    using DevExpress.Mvvm.UI.Interactivity;
+    using DevExpress.Xpf.Diagram;
+
+    /// <summary>
+    /// The view side of the traceability diagram: it applies the Sugiyama automatic layout in the orientation selected
+    /// on the <see cref="RelationshipTraceabilityViewModel"/> whenever the diagram items change, and exports the
+    /// diagram to a file
+    /// </summary>
+    public class TraceabilityDiagramBehavior : Behavior<DiagramControl>, ITraceabilityDiagramBehavior
+    {
+        /// <summary>
+        /// A value indicating whether a layout pass is already scheduled, used to coalesce the per-item
+        /// <see cref="DiagramControl.ItemsChanged"/> events into a single layout pass
+        /// </summary>
+        private bool layoutPending;
+
+        /// <summary>
+        /// The on attached event handler
+        /// </summary>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            this.AssociatedObject.DataContextChanged += this.OnDataContextChanged;
+            this.AssociatedObject.ItemsChanged += this.OnItemsChanged;
+            this.OnDataContextChanged(this.AssociatedObject, default);
+        }
+
+        /// <summary>
+        /// Unsubscribes event handlers when detaching
+        /// </summary>
+        protected override void OnDetaching()
+        {
+            this.AssociatedObject.DataContextChanged -= this.OnDataContextChanged;
+            this.AssociatedObject.ItemsChanged -= this.OnItemsChanged;
+
+            if (this.AssociatedObject.DataContext is RelationshipTraceabilityViewModel viewModel)
+            {
+                viewModel.Behavior = null;
+            }
+
+            base.OnDetaching();
+        }
+
+        /// <summary>
+        /// Applies the Sugiyama automatic layout in the orientation currently selected on the view-model and centers
+        /// the page
+        /// </summary>
+        public void ApplyLayout()
+        {
+            if (!this.AssociatedObject.Items.OfType<DiagramContentItem>().Any())
+            {
+                return;
+            }
+
+            var direction = (this.AssociatedObject.DataContext as RelationshipTraceabilityViewModel)?.LayoutDirection ?? Direction.Down;
+
+            this.AssociatedObject.ApplySugiyamaLayout(direction, this.AssociatedObject.Items);
+            this.AssociatedObject.AlignPage(HorizontalAlignment.Center, VerticalAlignment.Center);
+        }
+
+        /// <summary>
+        /// Exports the diagram to a file picked by the user
+        /// </summary>
+        /// <param name="format">The <see cref="DiagramExportFormat"/> to export to</param>
+        public void Export(DiagramExportFormat format)
+        {
+            var openSaveFileDialogService = ServiceLocator.Current.GetInstance<IOpenSaveFileDialogService>();
+            var extension = format.ToString().ToLower();
+            var result = openSaveFileDialogService.GetSaveFileDialog($"RelationshipTraceability-{DateTime.Now:yyyy-MM-dd_HH-mm}", $".{extension}", $"{format} file(*.{extension}) | *.{extension}; ", "", 0);
+
+            if (string.IsNullOrWhiteSpace(result))
+            {
+                return;
+            }
+
+            if (format == DiagramExportFormat.SVG)
+            {
+                // the built-in SVG export renders connectors but skips the templated node content, so the
+                // resulting file shows arrows without boxes; write the SVG from the laid-out items instead
+                System.IO.File.WriteAllText(result, this.BuildSvg());
+                return;
+            }
+
+            using (var writer = System.IO.File.Create(result))
+            {
+                this.AssociatedObject.ExportDiagram(writer, format, 72, 1);
+            }
+        }
+
+        /// <summary>
+        /// Builds an SVG document from the laid-out diagram items: a rounded, level-tinted box with the class kind,
+        /// short name and name per node, and a polyline per connector drawn in the true arrow direction of its
+        /// relationship
+        /// </summary>
+        /// <returns>The SVG document</returns>
+        private string BuildSvg()
+        {
+            var culture = CultureInfo.InvariantCulture;
+            var nodeItems = this.AssociatedObject.Items.OfType<DiagramContentItem>().Where(x => x.Content is TraceabilityNodeViewModel).ToList();
+            var connectors = this.AssociatedObject.Items.OfType<DiagramConnector>().ToList();
+
+            var minX = double.MaxValue;
+            var minY = double.MaxValue;
+            var maxX = double.MinValue;
+            var maxY = double.MinValue;
+
+            foreach (var item in nodeItems)
+            {
+                minX = Math.Min(minX, item.Position.X);
+                minY = Math.Min(minY, item.Position.Y);
+                maxX = Math.Max(maxX, item.Position.X + item.ActualWidth);
+                maxY = Math.Max(maxY, item.Position.Y + item.ActualHeight);
+            }
+
+            if (nodeItems.Count == 0)
+            {
+                minX = minY = 0;
+                maxX = maxY = 1;
+            }
+
+            const int margin = 20;
+            var builder = new StringBuilder();
+
+            builder.AppendLine(string.Format(culture, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"{0:0.##} {1:0.##} {2:0.##} {3:0.##}\" font-family=\"Segoe UI, sans-serif\">", minX - margin, minY - margin, maxX - minX + (2 * margin), maxY - minY + (2 * margin)));
+            builder.AppendLine("<defs><marker id=\"arrow\" viewBox=\"0 0 10 10\" refX=\"9\" refY=\"5\" markerWidth=\"8\" markerHeight=\"8\" orient=\"auto\"><path d=\"M 0 0 L 10 5 L 0 10 z\" fill=\"#4682B4\"/></marker></defs>");
+
+            foreach (var connector in connectors)
+            {
+                var edge = (connector.Content ?? connector.DataContext) as TraceabilityEdgeViewModel;
+
+                var points = new List<System.Windows.Point> { connector.ActualBeginPoint };
+                points.AddRange(connector.Points);
+                points.Add(connector.ActualEndPoint);
+
+                if (edge != null && edge.IsReversed)
+                {
+                    // draw the polyline in the true arrow direction, so the end marker lands on the right side
+                    points.Reverse();
+                }
+
+                var pointList = string.Join(" ", points.Select(p => string.Format(culture, "{0:0.##},{1:0.##}", p.X, p.Y)));
+                var marker = edge != null && edge.IsUndirected ? string.Empty : " marker-end=\"url(#arrow)\"";
+
+                builder.AppendLine($"<polyline points=\"{pointList}\" fill=\"none\" stroke=\"#4682B4\" stroke-width=\"1\"{marker}/>");
+            }
+
+            foreach (var item in nodeItems)
+            {
+                var node = (TraceabilityNodeViewModel)item.Content;
+                var fill = node.IsRoot ? "#FFE082" : node.Level > 0 ? "#BBDEFB" : "#C8E6C9";
+                var centerX = item.Position.X + (item.ActualWidth / 2);
+
+                builder.AppendLine(string.Format(culture, "<rect x=\"{0:0.##}\" y=\"{1:0.##}\" width=\"{2:0.##}\" height=\"{3:0.##}\" rx=\"3\" fill=\"{4}\" stroke=\"dimgray\"/>", item.Position.X, item.Position.Y, item.ActualWidth, item.ActualHeight, fill));
+                builder.AppendLine(string.Format(culture, "<text x=\"{0:0.##}\" y=\"{1:0.##}\" font-size=\"9\" fill=\"dimgray\" text-anchor=\"middle\">{2}</text>", centerX, item.Position.Y + 12, SecurityElement.Escape(node.ClassKindName)));
+                builder.AppendLine(string.Format(culture, "<text x=\"{0:0.##}\" y=\"{1:0.##}\" font-size=\"12\" font-weight=\"bold\" text-anchor=\"middle\">{2}</text>", centerX, item.Position.Y + 26, SecurityElement.Escape(node.ShortName)));
+                builder.AppendLine(string.Format(culture, "<text x=\"{0:0.##}\" y=\"{1:0.##}\" font-size=\"10\" text-anchor=\"middle\">{2}</text>", centerX, item.Position.Y + 40, SecurityElement.Escape(node.Name)));
+            }
+
+            builder.AppendLine("</svg>");
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Injects this behavior into the view-model when the data context arrives
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="e">The event arguments</param>
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (this.AssociatedObject.DataContext is RelationshipTraceabilityViewModel viewModel)
+            {
+                viewModel.Behavior = this;
+            }
+        }
+
+        /// <summary>
+        /// Schedules a single layout pass after the diagram items changed
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="e">The event arguments</param>
+        private void OnItemsChanged(object sender, DiagramItemsChangedEventArgs e)
+        {
+            if (e.Item is DiagramItem item)
+            {
+                item.CanDelete = false;
+            }
+
+            if (e.Item is DiagramConnector connector && (connector.Content ?? connector.DataContext) is TraceabilityEdgeViewModel edge)
+            {
+                // the connector runs in traversal-level order for the layout; the arrow head marks the true
+                // direction of the relationship, or no head at all for an undirected multi-relationship
+                connector.BeginArrow = edge.IsReversed && !edge.IsUndirected ? ArrowDescriptions.Filled90 : null;
+                connector.EndArrow = edge.IsReversed || edge.IsUndirected ? null : ArrowDescriptions.Filled90;
+            }
+
+            if (this.layoutPending)
+            {
+                return;
+            }
+
+            this.layoutPending = true;
+
+            this.AssociatedObject.Dispatcher.BeginInvoke(
+                new Action(() =>
+                {
+                    this.layoutPending = false;
+                    this.ApplyLayout();
+                }),
+                DispatcherPriority.Background);
+        }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/RelationshipGraph.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraph.cs
@@ -1,0 +1,72 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipGraph.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents the ephemeral result of a traversal performed by the <see cref="RelationshipGraphBuilder"/>. Nothing
+    /// in this graph is part of the model, it exists only to be rendered.
+    /// </summary>
+    public class RelationshipGraph
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipGraph"/> class
+        /// </summary>
+        /// <param name="nodes">
+        /// The <see cref="RelationshipGraphNode"/>s that were reached
+        /// </param>
+        /// <param name="edges">
+        /// The <see cref="RelationshipGraphEdge"/>s between the reached nodes
+        /// </param>
+        /// <param name="maxNodeCountReached">
+        /// A value indicating whether the traversal was cut short by <see cref="RelationshipGraphConfiguration.MaxNodes"/>
+        /// </param>
+        public RelationshipGraph(IReadOnlyList<RelationshipGraphNode> nodes, IReadOnlyList<RelationshipGraphEdge> edges, bool maxNodeCountReached)
+        {
+            this.Nodes = nodes;
+            this.Edges = edges;
+            this.MaxNodeCountReached = maxNodeCountReached;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="RelationshipGraphNode"/>s that were reached, the roots included
+        /// </summary>
+        public IReadOnlyList<RelationshipGraphNode> Nodes { get; }
+
+        /// <summary>
+        /// Gets the <see cref="RelationshipGraphEdge"/>s between the reached nodes
+        /// </summary>
+        public IReadOnlyList<RelationshipGraphEdge> Edges { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the traversal stopped because
+        /// <see cref="RelationshipGraphConfiguration.MaxNodes"/> was reached. When true the graph is incomplete and
+        /// the user is to be warned.
+        /// </summary>
+        public bool MaxNodeCountReached { get; }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphBuilder.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphBuilder.cs
@@ -92,8 +92,8 @@ namespace CDP4DiagramEditor.Helpers
         /// Builds the <see cref="RelationshipGraph"/> that is reachable from the supplied roots
         /// </summary>
         /// <param name="roots">
-        /// The <see cref="Thing"/>s the traversal starts from. They are always part of the resulting graph, the
-        /// <see cref="RelationshipGraphConfiguration.NodeFilter"/> is not applied to them.
+        /// The <see cref="Thing"/>s the traversal starts from. They are part of the resulting graph unless they are
+        /// excluded or deprecated.
         /// </param>
         /// <param name="configuration">
         /// The <see cref="RelationshipGraphConfiguration"/> that constrains the traversal
@@ -326,19 +326,14 @@ namespace CDP4DiagramEditor.Helpers
         /// The reached <see cref="Thing"/>
         /// </param>
         /// <param name="configuration">
-        /// The <see cref="RelationshipGraphConfiguration"/> holding the node filter and the excluded things
+        /// The <see cref="RelationshipGraphConfiguration"/> holding the excluded things
         /// </param>
         /// <returns>
         /// true when the <see cref="Thing"/> may be added
         /// </returns>
         private static bool IsNodeAllowed(Thing thing, RelationshipGraphConfiguration configuration)
         {
-            if (configuration.ExcludedThings.Contains(thing.Iid) || IsDeprecated(thing))
-            {
-                return false;
-            }
-
-            return configuration.NodeFilter == null || configuration.NodeFilter.IsMatch(thing);
+            return !configuration.ExcludedThings.Contains(thing.Iid) && !IsDeprecated(thing);
         }
 
         /// <summary>

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphBuilder.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphBuilder.cs
@@ -121,7 +121,9 @@ namespace CDP4DiagramEditor.Helpers
 
             foreach (var root in roots.Where(x => x != null))
             {
-                if (nodes.ContainsKey(root.Iid) || configuration.ExcludedThings.Contains(root.Iid))
+                // a root is not subject to the node filter, but it is subject to exclusion and deprecation, so that a
+                // deprecated thing never shows up as a root while every deprecated thing reached by traversal is hidden
+                if (nodes.ContainsKey(root.Iid) || configuration.ExcludedThings.Contains(root.Iid) || IsDeprecated(root))
                 {
                     continue;
                 }
@@ -235,6 +237,12 @@ namespace CDP4DiagramEditor.Helpers
                 }
 
                 currentLevelThings = nextLevelThings;
+
+                if (maxNodeCountReached)
+                {
+                    // no further node can be added, so any deeper level would only discard its results
+                    break;
+                }
             }
 
             return maxNodeCountReached;
@@ -325,17 +333,26 @@ namespace CDP4DiagramEditor.Helpers
         /// </returns>
         private static bool IsNodeAllowed(Thing thing, RelationshipGraphConfiguration configuration)
         {
-            if (configuration.ExcludedThings.Contains(thing.Iid))
-            {
-                return false;
-            }
-
-            if (thing is IDeprecatableThing deprecatableThing && deprecatableThing.IsDeprecated)
+            if (configuration.ExcludedThings.Contains(thing.Iid) || IsDeprecated(thing))
             {
                 return false;
             }
 
             return configuration.NodeFilter == null || configuration.NodeFilter.IsMatch(thing);
+        }
+
+        /// <summary>
+        /// Asserts whether a <see cref="Thing"/> is deprecated
+        /// </summary>
+        /// <param name="thing">
+        /// The <see cref="Thing"/> that is to be checked
+        /// </param>
+        /// <returns>
+        /// true when the <see cref="Thing"/> is an <see cref="IDeprecatableThing"/> that is deprecated
+        /// </returns>
+        private static bool IsDeprecated(Thing thing)
+        {
+            return thing is IDeprecatableThing deprecatableThing && deprecatableThing.IsDeprecated;
         }
     }
 }

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphBuilder.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphBuilder.cs
@@ -1,0 +1,341 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipGraphBuilder.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// Walks the <see cref="Relationship"/>s of an <see cref="Iteration"/> outward from a set of roots and returns the
+    /// reached <see cref="Thing"/>s as an ephemeral <see cref="RelationshipGraph"/>. This class is free of any
+    /// dependency on the UI and it never mutates the model.
+    /// </summary>
+    public class RelationshipGraphBuilder
+    {
+        /// <summary>
+        /// The <see cref="BinaryRelationship"/>s of the <see cref="Iteration"/>, indexed by the <see cref="Thing.Iid"/>
+        /// of their <see cref="BinaryRelationship.Source"/>
+        /// </summary>
+        private readonly ILookup<Guid, BinaryRelationship> binaryRelationshipsBySource;
+
+        /// <summary>
+        /// The <see cref="BinaryRelationship"/>s of the <see cref="Iteration"/>, indexed by the <see cref="Thing.Iid"/>
+        /// of their <see cref="BinaryRelationship.Target"/>
+        /// </summary>
+        private readonly ILookup<Guid, BinaryRelationship> binaryRelationshipsByTarget;
+
+        /// <summary>
+        /// The <see cref="MultiRelationship"/>s of the <see cref="Iteration"/>, indexed by the <see cref="Thing.Iid"/>
+        /// of each of their <see cref="MultiRelationship.RelatedThing"/>
+        /// </summary>
+        private readonly ILookup<Guid, MultiRelationship> multiRelationshipsByRelatedThing;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipGraphBuilder"/> class
+        /// </summary>
+        /// <param name="iteration">
+        /// The <see cref="Iteration"/> whose <see cref="Iteration.Relationship"/>s are traversed. The relationships are
+        /// indexed once, so a builder is to be recreated when they change.
+        /// </param>
+        public RelationshipGraphBuilder(Iteration iteration)
+        {
+            if (iteration == null)
+            {
+                throw new ArgumentNullException(nameof(iteration));
+            }
+
+            var binaryRelationships = iteration.Relationship
+                .OfType<BinaryRelationship>()
+                .Where(x => x.Source != null && x.Target != null)
+                .ToList();
+
+            this.binaryRelationshipsBySource = binaryRelationships.ToLookup(x => x.Source.Iid);
+            this.binaryRelationshipsByTarget = binaryRelationships.ToLookup(x => x.Target.Iid);
+
+            this.multiRelationshipsByRelatedThing = iteration.Relationship
+                .OfType<MultiRelationship>()
+                .SelectMany(
+                    multiRelationship => multiRelationship.RelatedThing
+                        .Where(relatedThing => relatedThing != null)
+                        .Select(relatedThing => new { relatedThing.Iid, MultiRelationship = multiRelationship }))
+                .ToLookup(x => x.Iid, x => x.MultiRelationship);
+        }
+
+        /// <summary>
+        /// Builds the <see cref="RelationshipGraph"/> that is reachable from the supplied roots
+        /// </summary>
+        /// <param name="roots">
+        /// The <see cref="Thing"/>s the traversal starts from. They are always part of the resulting graph, the
+        /// <see cref="RelationshipGraphConfiguration.NodeFilter"/> is not applied to them.
+        /// </param>
+        /// <param name="configuration">
+        /// The <see cref="RelationshipGraphConfiguration"/> that constrains the traversal
+        /// </param>
+        /// <returns>
+        /// The resulting <see cref="RelationshipGraph"/>
+        /// </returns>
+        public RelationshipGraph Build(IEnumerable<Thing> roots, RelationshipGraphConfiguration configuration)
+        {
+            if (roots == null)
+            {
+                throw new ArgumentNullException(nameof(roots));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var nodes = new Dictionary<Guid, RelationshipGraphNode>();
+            var edges = new List<RelationshipGraphEdge>();
+            var edgeKeys = new HashSet<Tuple<Guid, Guid, Guid>>();
+            var rootThings = new List<Thing>();
+            var maxNodeCountReached = false;
+
+            foreach (var root in roots.Where(x => x != null))
+            {
+                if (nodes.ContainsKey(root.Iid) || configuration.ExcludedThings.Contains(root.Iid))
+                {
+                    continue;
+                }
+
+                if (nodes.Count >= configuration.MaxNodes)
+                {
+                    maxNodeCountReached = true;
+                    break;
+                }
+
+                nodes.Add(root.Iid, new RelationshipGraphNode(root, 0));
+                rootThings.Add(root);
+            }
+
+            if (this.Expand(rootThings, configuration, 1, nodes, edges, edgeKeys))
+            {
+                maxNodeCountReached = true;
+            }
+
+            if (this.Expand(rootThings, configuration, -1, nodes, edges, edgeKeys))
+            {
+                maxNodeCountReached = true;
+            }
+
+            return new RelationshipGraph(nodes.Values.ToList(), edges, maxNodeCountReached);
+        }
+
+        /// <summary>
+        /// Performs a breadth-first expansion in a single direction, adding the reached <see cref="Thing"/>s and the
+        /// traversed <see cref="Relationship"/>s to the graph that is under construction
+        /// </summary>
+        /// <param name="roots">
+        /// The <see cref="Thing"/>s the expansion starts from
+        /// </param>
+        /// <param name="configuration">
+        /// The <see cref="RelationshipGraphConfiguration"/> that constrains the traversal
+        /// </param>
+        /// <param name="direction">
+        /// 1 to expand downward, -1 to expand upward
+        /// </param>
+        /// <param name="nodes">
+        /// The nodes of the graph under construction, keyed by <see cref="Thing.Iid"/>
+        /// </param>
+        /// <param name="edges">
+        /// The edges of the graph under construction
+        /// </param>
+        /// <param name="edgeKeys">
+        /// The keys of the edges that were already added, used to keep the downward and upward expansion from adding
+        /// the same edge twice
+        /// </param>
+        /// <returns>
+        /// true when the expansion was cut short by <see cref="RelationshipGraphConfiguration.MaxNodes"/>
+        /// </returns>
+        private bool Expand(IReadOnlyList<Thing> roots, RelationshipGraphConfiguration configuration, int direction, IDictionary<Guid, RelationshipGraphNode> nodes, ICollection<RelationshipGraphEdge> edges, ISet<Tuple<Guid, Guid, Guid>> edgeKeys)
+        {
+            var depth = direction > 0 ? configuration.DepthDown : configuration.DepthUp;
+
+            if (depth <= 0)
+            {
+                return false;
+            }
+
+            var maxNodeCountReached = false;
+
+            // a visited set per direction, so that a thing that was reached downward can still be reached upward
+            var visited = new HashSet<Guid>(roots.Select(x => x.Iid));
+            var currentLevelThings = roots.ToList();
+
+            for (var level = 1; level <= depth && currentLevelThings.Any(); level++)
+            {
+                var levelFilter = configuration.QueryLevelFilter(level);
+                var traversalDirection = levelFilter?.Direction ?? (direction > 0 ? RelationshipTraversalDirection.AlongArrows : RelationshipTraversalDirection.AgainstArrows);
+                var nextLevelThings = new List<Thing>();
+
+                foreach (var thing in currentLevelThings)
+                {
+                    foreach (var traversal in this.QueryTraversals(thing, traversalDirection))
+                    {
+                        if (levelFilter != null && !levelFilter.IsMatch(traversal.Relationship))
+                        {
+                            continue;
+                        }
+
+                        if (!IsNodeAllowed(traversal.RelatedThing, configuration))
+                        {
+                            continue;
+                        }
+
+                        if (!nodes.ContainsKey(traversal.RelatedThing.Iid))
+                        {
+                            if (nodes.Count >= configuration.MaxNodes)
+                            {
+                                // keep scanning: edges between things that are already on the diagram are still added
+                                maxNodeCountReached = true;
+                                continue;
+                            }
+
+                            nodes.Add(traversal.RelatedThing.Iid, new RelationshipGraphNode(traversal.RelatedThing, direction * level));
+                        }
+
+                        if (edgeKeys.Add(BuildEdgeKey(traversal.Relationship, traversal.EdgeSource, traversal.EdgeTarget)))
+                        {
+                            edges.Add(new RelationshipGraphEdge(traversal.EdgeSource, traversal.EdgeTarget, traversal.Relationship));
+                        }
+
+                        if (visited.Add(traversal.RelatedThing.Iid))
+                        {
+                            nextLevelThings.Add(traversal.RelatedThing);
+                        }
+                    }
+                }
+
+                currentLevelThings = nextLevelThings;
+            }
+
+            return maxNodeCountReached;
+        }
+
+        /// <summary>
+        /// Builds the deduplication key of an edge. A <see cref="MultiRelationship"/> edge is keyed on its unordered
+        /// endpoints, because entering the relationship through either endpoint yields the same edge and must not
+        /// produce a duplicate.
+        /// </summary>
+        /// <param name="relationship">The traversed <see cref="Relationship"/></param>
+        /// <param name="edgeSource">The <see cref="Thing"/> the edge originates from</param>
+        /// <param name="edgeTarget">The <see cref="Thing"/> the edge points to</param>
+        /// <returns>The key that identifies the edge</returns>
+        private static Tuple<Guid, Guid, Guid> BuildEdgeKey(Relationship relationship, Thing edgeSource, Thing edgeTarget)
+        {
+            if (relationship is MultiRelationship && edgeTarget.Iid.CompareTo(edgeSource.Iid) < 0)
+            {
+                return new Tuple<Guid, Guid, Guid>(relationship.Iid, edgeTarget.Iid, edgeSource.Iid);
+            }
+
+            return new Tuple<Guid, Guid, Guid>(relationship.Iid, edgeSource.Iid, edgeTarget.Iid);
+        }
+
+        /// <summary>
+        /// Queries the <see cref="Relationship"/>s that leave the supplied <see cref="Thing"/> in the supplied
+        /// traversal direction
+        /// </summary>
+        /// <param name="thing">
+        /// The <see cref="Thing"/> that is being expanded
+        /// </param>
+        /// <param name="traversalDirection">
+        /// The <see cref="RelationshipTraversalDirection"/> in which <see cref="BinaryRelationship"/> arrows are
+        /// followed at this hop
+        /// </param>
+        /// <returns>
+        /// For each traversable <see cref="Relationship"/> the <see cref="Thing"/> that is reached through it and the
+        /// two <see cref="Thing"/>s the resulting edge is to be drawn between
+        /// </returns>
+        /// <remarks>
+        /// A <see cref="MultiRelationship"/> is undirected and is therefore expanded in both directions: entering it
+        /// through any of its <see cref="MultiRelationship.RelatedThing"/>s reaches all the others, at the cost of a
+        /// single level.
+        /// </remarks>
+        private IEnumerable<(Relationship Relationship, Thing RelatedThing, Thing EdgeSource, Thing EdgeTarget)> QueryTraversals(Thing thing, RelationshipTraversalDirection traversalDirection)
+        {
+            if (traversalDirection != RelationshipTraversalDirection.AgainstArrows)
+            {
+                foreach (var binaryRelationship in this.binaryRelationshipsBySource[thing.Iid])
+                {
+                    yield return (binaryRelationship, binaryRelationship.Target, binaryRelationship.Source, binaryRelationship.Target);
+                }
+            }
+
+            if (traversalDirection != RelationshipTraversalDirection.AlongArrows)
+            {
+                foreach (var binaryRelationship in this.binaryRelationshipsByTarget[thing.Iid])
+                {
+                    yield return (binaryRelationship, binaryRelationship.Source, binaryRelationship.Source, binaryRelationship.Target);
+                }
+            }
+
+            foreach (var multiRelationship in this.multiRelationshipsByRelatedThing[thing.Iid])
+            {
+                foreach (var relatedThing in multiRelationship.RelatedThing)
+                {
+                    if (relatedThing == null || relatedThing.Iid == thing.Iid)
+                    {
+                        continue;
+                    }
+
+                    yield return (multiRelationship, relatedThing, thing, relatedThing);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asserts whether a reached <see cref="Thing"/> may be added to the graph
+        /// </summary>
+        /// <param name="thing">
+        /// The reached <see cref="Thing"/>
+        /// </param>
+        /// <param name="configuration">
+        /// The <see cref="RelationshipGraphConfiguration"/> holding the node filter and the excluded things
+        /// </param>
+        /// <returns>
+        /// true when the <see cref="Thing"/> may be added
+        /// </returns>
+        private static bool IsNodeAllowed(Thing thing, RelationshipGraphConfiguration configuration)
+        {
+            if (configuration.ExcludedThings.Contains(thing.Iid))
+            {
+                return false;
+            }
+
+            if (thing is IDeprecatableThing deprecatableThing && deprecatableThing.IsDeprecated)
+            {
+                return false;
+            }
+
+            return configuration.NodeFilter == null || configuration.NodeFilter.IsMatch(thing);
+        }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphConfiguration.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphConfiguration.cs
@@ -1,0 +1,117 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipGraphConfiguration.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// Represents the configuration that drives the <see cref="RelationshipGraphBuilder"/>: how many levels to
+    /// traverse in each direction, which <see cref="Relationship"/>s may be followed at each level and which
+    /// reached <see cref="Thing"/>s are kept.
+    /// </summary>
+    public class RelationshipGraphConfiguration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipGraphConfiguration"/> class
+        /// </summary>
+        public RelationshipGraphConfiguration()
+        {
+            this.DepthDown = 2;
+            this.DepthUp = 0;
+            this.MaxNodes = 300;
+            this.LevelFilterOverrides = new Dictionary<int, RelationshipGraphFilter>();
+            this.ExcludedThings = new HashSet<Guid>();
+        }
+
+        /// <summary>
+        /// Gets or sets the number of levels that are traversed in the downward direction, that is following a
+        /// <see cref="BinaryRelationship"/> from its <see cref="BinaryRelationship.Source"/> to its
+        /// <see cref="BinaryRelationship.Target"/>. A value of zero or less disables downward traversal.
+        /// </summary>
+        public int DepthDown { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of levels that are traversed in the upward direction, that is following a
+        /// <see cref="BinaryRelationship"/> from its <see cref="BinaryRelationship.Target"/> to its
+        /// <see cref="BinaryRelationship.Source"/>. A value of zero or less disables upward traversal.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="MultiRelationship"/> is undirected, it is therefore expanded in both directions.
+        /// </remarks>
+        public int DepthUp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of nodes that the resulting <see cref="RelationshipGraph"/> may contain.
+        /// Traversal stops once this number is reached and <see cref="RelationshipGraph.MaxNodeCountReached"/> is set.
+        /// </summary>
+        public int MaxNodes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="RelationshipGraphFilter"/> that a <see cref="Relationship"/> must match to be
+        /// followed, at any level for which no override is registered in <see cref="LevelFilterOverrides"/>. A null
+        /// value means that every <see cref="Relationship"/> is followed.
+        /// </summary>
+        public RelationshipGraphFilter DefaultLevelFilter { get; set; }
+
+        /// <summary>
+        /// Gets the per-level overrides of <see cref="DefaultLevelFilter"/>, keyed by the one-based level at which
+        /// they apply.
+        /// </summary>
+        public Dictionary<int, RelationshipGraphFilter> LevelFilterOverrides { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="RelationshipGraphFilter"/> that a reached <see cref="Thing"/> must match to be
+        /// added to the graph. A null value means that every reached <see cref="Thing"/> is added.
+        /// </summary>
+        public RelationshipGraphFilter NodeFilter { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="Thing.Iid"/>s of the <see cref="Thing"/>s that are excluded from the graph. An excluded
+        /// <see cref="Thing"/> is never added as a node, so everything that is only reachable through it disappears
+        /// with it.
+        /// </summary>
+        public HashSet<Guid> ExcludedThings { get; }
+
+        /// <summary>
+        /// Queries the <see cref="RelationshipGraphFilter"/> that applies to the supplied level
+        /// </summary>
+        /// <param name="level">
+        /// The one-based level that is about to be traversed
+        /// </param>
+        /// <returns>
+        /// The registered override for <paramref name="level"/>, or <see cref="DefaultLevelFilter"/> when no override
+        /// is registered
+        /// </returns>
+        public RelationshipGraphFilter QueryLevelFilter(int level)
+        {
+            return this.LevelFilterOverrides.TryGetValue(level, out var filter) ? filter : this.DefaultLevelFilter;
+        }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphConfiguration.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphConfiguration.cs
@@ -87,12 +87,6 @@ namespace CDP4DiagramEditor.Helpers
         public Dictionary<int, RelationshipGraphFilter> LevelFilterOverrides { get; }
 
         /// <summary>
-        /// Gets or sets the <see cref="RelationshipGraphFilter"/> that a reached <see cref="Thing"/> must match to be
-        /// added to the graph. A null value means that every reached <see cref="Thing"/> is added.
-        /// </summary>
-        public RelationshipGraphFilter NodeFilter { get; set; }
-
-        /// <summary>
         /// Gets the <see cref="Thing.Iid"/>s of the <see cref="Thing"/>s that are excluded from the graph. An excluded
         /// <see cref="Thing"/> is never added as a node, so everything that is only reachable through it disappears
         /// with it.

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphEdge.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphEdge.cs
@@ -1,0 +1,73 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipGraphEdge.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// Represents a <see cref="Relationship"/> between two <see cref="RelationshipGraphNode"/>s
+    /// </summary>
+    public class RelationshipGraphEdge
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipGraphEdge"/> class
+        /// </summary>
+        /// <param name="source">
+        /// The <see cref="Thing"/> the edge originates from
+        /// </param>
+        /// <param name="target">
+        /// The <see cref="Thing"/> the edge points to
+        /// </param>
+        /// <param name="relationship">
+        /// The <see cref="Relationship"/> that the edge depicts
+        /// </param>
+        public RelationshipGraphEdge(Thing source, Thing target, Relationship relationship)
+        {
+            this.Source = source;
+            this.Target = target;
+            this.Relationship = relationship;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Thing"/> the edge originates from. For a <see cref="BinaryRelationship"/> this is always
+        /// its <see cref="BinaryRelationship.Source"/>, irrespective of the direction it was traversed in. For a
+        /// <see cref="MultiRelationship"/>, which is undirected, this is the <see cref="Thing"/> the traversal entered
+        /// the relationship through.
+        /// </summary>
+        public Thing Source { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Thing"/> the edge points to
+        /// </summary>
+        public Thing Target { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Relationship"/> that the edge depicts
+        /// </summary>
+        public Relationship Relationship { get; }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphFilter.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphFilter.cs
@@ -33,8 +33,9 @@ namespace CDP4DiagramEditor.Helpers
     using CDP4Common.SiteDirectoryData;
 
     /// <summary>
-    /// Represents a filter on a <see cref="Thing"/> by <see cref="ClassKind"/> and by <see cref="Category"/>. It is used
-    /// both to decide which <see cref="Relationship"/>s may be followed and which reached <see cref="Thing"/>s are kept.
+    /// Represents a filter on a <see cref="Thing"/> by <see cref="Category"/> and, for a <see cref="Relationship"/>,
+    /// by the direction its arrows are followed in. It is used to decide which <see cref="Relationship"/>s may be
+    /// followed at a traversal level and which <see cref="Thing"/>s make up the root set.
     /// </summary>
     public class RelationshipGraphFilter
     {
@@ -43,15 +44,8 @@ namespace CDP4DiagramEditor.Helpers
         /// </summary>
         public RelationshipGraphFilter()
         {
-            this.ClassKinds = new List<ClassKind>();
             this.Categories = new List<Category>();
         }
-
-        /// <summary>
-        /// Gets the <see cref="ClassKind"/>s that are accepted. An empty collection accepts every
-        /// <see cref="ClassKind"/>.
-        /// </summary>
-        public List<ClassKind> ClassKinds { get; }
 
         /// <summary>
         /// Gets or sets how <see cref="BinaryRelationship"/> arrows are followed at the hops this filter applies to.
@@ -85,11 +79,6 @@ namespace CDP4DiagramEditor.Helpers
         /// </returns>
         public bool IsMatch(Thing thing)
         {
-            if (this.ClassKinds.Any() && !this.ClassKinds.Contains(thing.ClassKind))
-            {
-                return false;
-            }
-
             if (!this.Categories.Any())
             {
                 return true;

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphFilter.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphFilter.cs
@@ -1,0 +1,111 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipGraphFilter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Represents a filter on a <see cref="Thing"/> by <see cref="ClassKind"/> and by <see cref="Category"/>. It is used
+    /// both to decide which <see cref="Relationship"/>s may be followed and which reached <see cref="Thing"/>s are kept.
+    /// </summary>
+    public class RelationshipGraphFilter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipGraphFilter"/> class
+        /// </summary>
+        public RelationshipGraphFilter()
+        {
+            this.ClassKinds = new List<ClassKind>();
+            this.Categories = new List<Category>();
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ClassKind"/>s that are accepted. An empty collection accepts every
+        /// <see cref="ClassKind"/>.
+        /// </summary>
+        public List<ClassKind> ClassKinds { get; }
+
+        /// <summary>
+        /// Gets or sets how <see cref="BinaryRelationship"/> arrows are followed at the hops this filter applies to.
+        /// A null value follows the natural direction of the traversal: along the arrows when expanding downward,
+        /// against them when expanding upward. Overriding this allows a hierarchy whose relationship arrows change
+        /// direction along the chain (for instance requirement decomposition pointing down but an equipment-satisfies
+        /// link pointing up) to be traversed in one pass. It has no effect on the undirected
+        /// <see cref="MultiRelationship"/>s and does not change how edges are drawn.
+        /// </summary>
+        public RelationshipTraversalDirection? Direction { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="Category"/>s that are accepted, sub categories included. An empty collection accepts
+        /// every <see cref="Category"/>, including things that are not categorizable at all.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="BinaryRelationshipRule"/> or <see cref="MultiRelationshipRule"/> is not modelled separately:
+        /// a rule reduces to its <see cref="Category"/>, so the caller adds
+        /// <see cref="BinaryRelationshipRule.RelationshipCategory"/> here.
+        /// </remarks>
+        public List<Category> Categories { get; }
+
+        /// <summary>
+        /// Asserts whether the supplied <see cref="Thing"/> matches this filter
+        /// </summary>
+        /// <param name="thing">
+        /// The <see cref="Thing"/> that is to be checked
+        /// </param>
+        /// <returns>
+        /// true when the <see cref="Thing"/> matches every populated facet of this filter
+        /// </returns>
+        public bool IsMatch(Thing thing)
+        {
+            if (this.ClassKinds.Any() && !this.ClassKinds.Contains(thing.ClassKind))
+            {
+                return false;
+            }
+
+            if (!this.Categories.Any())
+            {
+                return true;
+            }
+
+            if (!(thing is ICategorizableThing categorizableThing))
+            {
+                return false;
+            }
+
+            // GetAllCategories walks up the super category chain of the categories of the thing itself, which is the
+            // cheap direction. The Category.AllDerivedCategories alternative scans the complete assembler cache on
+            // every call and is unusable in the traversal loop.
+            var allCategories = new HashSet<Category>(categorizableThing.GetAllCategories());
+
+            return this.Categories.Any(allCategories.Contains);
+        }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/RelationshipGraphNode.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipGraphNode.cs
@@ -1,0 +1,61 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipGraphNode.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using CDP4Common.CommonData;
+
+    /// <summary>
+    /// Represents a <see cref="Thing"/> that was reached by the <see cref="RelationshipGraphBuilder"/>
+    /// </summary>
+    public class RelationshipGraphNode
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipGraphNode"/> class
+        /// </summary>
+        /// <param name="thing">
+        /// The <see cref="Thing"/> that was reached
+        /// </param>
+        /// <param name="level">
+        /// The level at which the <see cref="Thing"/> was first reached
+        /// </param>
+        public RelationshipGraphNode(Thing thing, int level)
+        {
+            this.Thing = thing;
+            this.Level = level;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Thing"/> that was reached
+        /// </summary>
+        public Thing Thing { get; }
+
+        /// <summary>
+        /// Gets the level at which the <see cref="Thing"/> was first reached: zero for a root, a positive number of
+        /// levels downward and a negative number of levels upward.
+        /// </summary>
+        public int Level { get; }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/RelationshipTraversalDirection.cs
+++ b/CDP4DiagramEditor/Helpers/RelationshipTraversalDirection.cs
@@ -1,0 +1,52 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipTraversalDirection.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// Enumerates how <see cref="BinaryRelationship"/> arrows are followed at a traversal hop
+    /// </summary>
+    public enum RelationshipTraversalDirection
+    {
+        /// <summary>
+        /// Follow relationships from their <see cref="BinaryRelationship.Source"/> to their
+        /// <see cref="BinaryRelationship.Target"/>
+        /// </summary>
+        AlongArrows,
+
+        /// <summary>
+        /// Follow relationships from their <see cref="BinaryRelationship.Target"/> to their
+        /// <see cref="BinaryRelationship.Source"/>
+        /// </summary>
+        AgainstArrows,
+
+        /// <summary>
+        /// Follow relationships in both directions
+        /// </summary>
+        Both
+    }
+}

--- a/CDP4DiagramEditor/Helpers/TraceabilityCategoryListConverter.cs
+++ b/CDP4DiagramEditor/Helpers/TraceabilityCategoryListConverter.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityCategoryListConverter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System.Collections.Generic;
+
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Converts the edit value of a checked combo box to a <see cref="List{T}"/> of <see cref="Category"/>
+    /// </summary>
+    public class TraceabilityCategoryListConverter : TraceabilityListConverter<Category>
+    {
+    }
+}

--- a/CDP4DiagramEditor/Helpers/TraceabilityClassKindListConverter.cs
+++ b/CDP4DiagramEditor/Helpers/TraceabilityClassKindListConverter.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityClassKindListConverter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System.Collections.Generic;
+
+    using CDP4Common.CommonData;
+
+    /// <summary>
+    /// Converts the edit value of a checked combo box to a <see cref="List{T}"/> of <see cref="ClassKind"/>
+    /// </summary>
+    public class TraceabilityClassKindListConverter : TraceabilityListConverter<ClassKind>
+    {
+    }
+}

--- a/CDP4DiagramEditor/Helpers/TraceabilityIntegerConverter.cs
+++ b/CDP4DiagramEditor/Helpers/TraceabilityIntegerConverter.cs
@@ -1,0 +1,80 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityIntegerConverter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System;
+    using System.Globalization;
+    using System.Windows.Data;
+
+    /// <summary>
+    /// Converts between the <see cref="decimal"/> value of a spin editor and an <see cref="int"/> view-model
+    /// property. WPF cannot convert <see cref="decimal"/> to <see cref="int"/> on its own, which surfaces as a
+    /// "Value could not be converted" validation error while typing.
+    /// </summary>
+    public class TraceabilityIntegerConverter : IValueConverter
+    {
+        /// <summary>
+        /// Converts the <see cref="int"/> view-model value to the <see cref="decimal"/> the spin editor expects
+        /// </summary>
+        /// <param name="value">The incoming value</param>
+        /// <param name="targetType">The target type</param>
+        /// <param name="parameter">The converter parameter, not used</param>
+        /// <param name="culture">The culture information, not used</param>
+        /// <returns>The value as <see cref="decimal"/></returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                return value == null ? 0m : System.Convert.ToDecimal(value, culture);
+            }
+            catch (Exception)
+            {
+                // a value the binding engine cannot supply, such as DependencyProperty.UnsetValue
+                return 0m;
+            }
+        }
+
+        /// <summary>
+        /// Converts the edited value back to an <see cref="int"/>
+        /// </summary>
+        /// <param name="value">The incoming value</param>
+        /// <param name="targetType">The target type</param>
+        /// <param name="parameter">The converter parameter, not used</param>
+        /// <param name="culture">The culture information, not used</param>
+        /// <returns>The value as <see cref="int"/>, or <see cref="Binding.DoNothing"/> while the text is not a number</returns>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                return value == null ? Binding.DoNothing : System.Convert.ToInt32(value, culture);
+            }
+            catch (Exception)
+            {
+                return Binding.DoNothing;
+            }
+        }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/TraceabilityLevelToBrushConverter.cs
+++ b/CDP4DiagramEditor/Helpers/TraceabilityLevelToBrushConverter.cs
@@ -1,0 +1,90 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityLevelToBrushConverter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System;
+    using System.Globalization;
+    using System.Windows.Data;
+    using System.Windows.Media;
+
+    /// <summary>
+    /// Converts the level of a traceability node to the brush of its diagram item: roots are highlighted, upward and
+    /// downward nodes get distinct tints so the traversal direction is readable at a glance
+    /// </summary>
+    public class TraceabilityLevelToBrushConverter : IValueConverter
+    {
+        /// <summary>
+        /// The brush of a root node
+        /// </summary>
+        private static readonly Brush RootBrush = new SolidColorBrush(Color.FromRgb(255, 224, 130));
+
+        /// <summary>
+        /// The brush of a node reached downward
+        /// </summary>
+        private static readonly Brush DownBrush = new SolidColorBrush(Color.FromRgb(187, 222, 251));
+
+        /// <summary>
+        /// The brush of a node reached upward
+        /// </summary>
+        private static readonly Brush UpBrush = new SolidColorBrush(Color.FromRgb(200, 230, 201));
+
+        /// <summary>
+        /// Converts a node level to a <see cref="Brush"/>
+        /// </summary>
+        /// <param name="value">The level of the node</param>
+        /// <param name="targetType">The target type</param>
+        /// <param name="parameter">The converter parameter, not used</param>
+        /// <param name="culture">The culture information, not used</param>
+        /// <returns>The <see cref="Brush"/> of the node</returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is int level))
+            {
+                return DownBrush;
+            }
+
+            if (level == 0)
+            {
+                return RootBrush;
+            }
+
+            return level > 0 ? DownBrush : UpBrush;
+        }
+
+        /// <summary>
+        /// Not supported
+        /// </summary>
+        /// <param name="value">The incoming value</param>
+        /// <param name="targetType">The target type</param>
+        /// <param name="parameter">The converter parameter, not used</param>
+        /// <param name="culture">The culture information, not used</param>
+        /// <returns>Throws <see cref="NotSupportedException"/></returns>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/CDP4DiagramEditor/Helpers/TraceabilityListConverter.cs
+++ b/CDP4DiagramEditor/Helpers/TraceabilityListConverter.cs
@@ -1,0 +1,67 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityListConverter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Helpers
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Windows.Data;
+
+    /// <summary>
+    /// Converts the edit value of a checked combo box to a <see cref="List{T}"/> of the item type, in both directions
+    /// </summary>
+    /// <typeparam name="T">The item type of the list</typeparam>
+    public abstract class TraceabilityListConverter<T> : IValueConverter
+    {
+        /// <summary>
+        /// Converts the incoming collection to a <see cref="List{T}"/>
+        /// </summary>
+        /// <param name="value">The incoming value</param>
+        /// <param name="targetType">The target type</param>
+        /// <param name="parameter">The converter parameter, not used</param>
+        /// <param name="culture">The culture information, not used</param>
+        /// <returns>The <see cref="List{T}"/></returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value is IList list ? list.Cast<T>().ToList() : new List<T>();
+        }
+
+        /// <summary>
+        /// Converts the edited collection back to a <see cref="List{T}"/>
+        /// </summary>
+        /// <param name="value">The incoming value</param>
+        /// <param name="targetType">The target type</param>
+        /// <param name="parameter">The converter parameter, not used</param>
+        /// <param name="culture">The culture information, not used</param>
+        /// <returns>The <see cref="List{T}"/></returns>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.Convert(value, targetType, parameter, culture);
+        }
+    }
+}

--- a/CDP4DiagramEditor/Settings/DiagramEditorPluginSettings.cs
+++ b/CDP4DiagramEditor/Settings/DiagramEditorPluginSettings.cs
@@ -1,0 +1,58 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DiagramEditorPluginSettings.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Settings
+{
+    using System.Collections.Generic;
+
+    using CDP4Common.CommonData;
+
+    using CDP4Composition.PluginSettingService;
+
+    /// <summary>
+    /// Represents the persisted settings of the <see cref="CDP4DiagramEditorModule"/> plugin. The inherited
+    /// <see cref="PluginSettings.SavedConfigurations"/> collection holds the saved
+    /// <see cref="TraceabilityConfiguration"/> presets.
+    /// </summary>
+    public class DiagramEditorPluginSettings : PluginSettings
+    {
+        /// <summary>
+        /// The set of <see cref="ClassKind"/>s offered by the traceability diagram pickers, the same curated set the
+        /// Relationship Matrix uses instead of every categorizable <see cref="ClassKind"/> of the model
+        /// </summary>
+        public static readonly IReadOnlyList<ClassKind> DefaultClassKinds = new List<ClassKind>
+        {
+            ClassKind.ElementDefinition,
+            ClassKind.ElementUsage,
+            ClassKind.NestedElement,
+            ClassKind.Option,
+            ClassKind.Parameter,
+            ClassKind.ParametricConstraint,
+            ClassKind.RequirementsSpecification,
+            ClassKind.RequirementsGroup,
+            ClassKind.Requirement
+        };
+    }
+}

--- a/CDP4DiagramEditor/Settings/TraceabilityConfiguration.cs
+++ b/CDP4DiagramEditor/Settings/TraceabilityConfiguration.cs
@@ -1,0 +1,116 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityConfiguration.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Settings
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Services.PluginSettingService;
+
+    using CDP4DiagramEditor.Helpers;
+
+    using DevExpress.Diagram.Core;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// Represents a serializable, named traceability diagram configuration that can be saved and reloaded as a preset.
+    /// The explicitly dropped root <see cref="Thing"/>s are session specific and are deliberately not part of a preset;
+    /// only the <see cref="Category"/> and <see cref="ClassKind"/> driven parts are persisted.
+    /// </summary>
+    public class TraceabilityConfiguration : IPluginSavedConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the saved configuration
+        /// </summary>
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        /// <summary>
+        /// Gets or sets the name of the saved configuration
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the saved configuration
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ClassKind"/>s that define the root set, or empty when the roots are only the
+        /// explicitly dropped <see cref="Thing"/>s
+        /// </summary>
+        [JsonProperty(ItemConverterType = typeof(StringEnumConverter))]
+        public List<ClassKind> RootClassKinds { get; set; } = new List<ClassKind>();
+
+        /// <summary>
+        /// Gets or sets the <see cref="Thing.Iid"/>s of the <see cref="Category"/>s that the root set is filtered by
+        /// </summary>
+        public List<Guid> RootCategories { get; set; } = new List<Guid>();
+
+        /// <summary>
+        /// Gets or sets the number of levels that are traversed downward
+        /// </summary>
+        public int DepthDown { get; set; } = 2;
+
+        /// <summary>
+        /// Gets or sets the number of levels that are traversed upward
+        /// </summary>
+        public int DepthUp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of nodes that the diagram may contain
+        /// </summary>
+        public int MaxNodes { get; set; } = 300;
+
+        /// <summary>
+        /// Gets or sets the orientation of the automatic layout
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Direction LayoutDirection { get; set; } = Direction.Down;
+
+        /// <summary>
+        /// Gets or sets the <see cref="Thing.Iid"/>s of the <see cref="Category"/>s that a relationship must be a
+        /// member of to be followed, at any level without an override. Empty means every relationship is followed.
+        /// </summary>
+        public List<Guid> DefaultLevelCategories { get; set; } = new List<Guid>();
+
+        /// <summary>
+        /// Gets or sets how relationship arrows are followed at levels without an override, or null for the natural
+        /// direction of the expansion
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RelationshipTraversalDirection? DefaultDirection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the per-level overrides of <see cref="DefaultLevelCategories"/>
+        /// </summary>
+        public List<TraceabilityLevelOverride> LevelOverrides { get; set; } = new List<TraceabilityLevelOverride>();
+    }
+}

--- a/CDP4DiagramEditor/Settings/TraceabilityLevelOverride.cs
+++ b/CDP4DiagramEditor/Settings/TraceabilityLevelOverride.cs
@@ -1,0 +1,63 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityLevelOverride.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Settings
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4DiagramEditor.Helpers;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// Represents the serializable per-level override of the default relationship filter of a
+    /// <see cref="TraceabilityConfiguration"/>
+    /// </summary>
+    public class TraceabilityLevelOverride
+    {
+        /// <summary>
+        /// Gets or sets the one-based level at which the override applies
+        /// </summary>
+        public int Level { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets how relationship arrows are followed at this level, or null for the natural direction of the
+        /// expansion
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RelationshipTraversalDirection? Direction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Thing.Iid"/>s of the <see cref="Category"/>s that a relationship must be a
+        /// member of to be followed at this level
+        /// </summary>
+        public List<Guid> Categories { get; set; } = new List<Guid>();
+    }
+}

--- a/CDP4DiagramEditor/ViewModels/RelationshipTraceabilityRibbonViewModel.cs
+++ b/CDP4DiagramEditor/ViewModels/RelationshipTraceabilityRibbonViewModel.cs
@@ -1,0 +1,68 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipTraceabilityRibbonViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.ViewModels
+{
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Composition.Mvvm;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.PluginSettingService;
+
+    using CDP4Dal;
+
+    /// <summary>
+    /// The view-model of the ribbon control that opens the <see cref="RelationshipTraceabilityViewModel"/> panel for
+    /// an open <see cref="Iteration"/>
+    /// </summary>
+    public class RelationshipTraceabilityRibbonViewModel : RibbonButtonIterationDependentViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipTraceabilityRibbonViewModel"/> class
+        /// </summary>
+        /// <param name="messageBus">
+        /// The <see cref="ICDPMessageBus"/>
+        /// </param>
+        public RelationshipTraceabilityRibbonViewModel(ICDPMessageBus messageBus) : base(InstantiatePanelViewModel, messageBus)
+        {
+        }
+
+        /// <summary>
+        /// Returns an instance of the <see cref="RelationshipTraceabilityViewModel"/> class
+        /// </summary>
+        /// <param name="iteration">The <see cref="Iteration"/> containing the information</param>
+        /// <param name="session">The <see cref="ISession"/></param>
+        /// <param name="thingDialogNavigationService">The <see cref="IThingDialogNavigationService"/></param>
+        /// <param name="panelNavigationService">The <see cref="IPanelNavigationService"/></param>
+        /// <param name="dialogNavigationService">The <see cref="IDialogNavigationService"/></param>
+        /// <param name="pluginSettingsService">The <see cref="IPluginSettingsService"/></param>
+        /// <returns>An instance of <see cref="RelationshipTraceabilityViewModel"/></returns>
+        public static RelationshipTraceabilityViewModel InstantiatePanelViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+        {
+            return new RelationshipTraceabilityViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+        }
+    }
+}

--- a/CDP4DiagramEditor/ViewModels/RelationshipTraceabilityViewModel.cs
+++ b/CDP4DiagramEditor/ViewModels/RelationshipTraceabilityViewModel.cs
@@ -29,6 +29,7 @@ namespace CDP4DiagramEditor.ViewModels
     using System.Collections.Generic;
     using System.Linq;
     using System.Reactive;
+    using System.Reactive.Disposables;
     using System.Reactive.Linq;
     using System.Threading.Tasks;
     using System.Windows;
@@ -83,6 +84,12 @@ namespace CDP4DiagramEditor.ViewModels
         /// relationship indexes are not rebuilt on every configuration change
         /// </summary>
         private RelationshipGraphBuilder builder;
+
+        /// <summary>
+        /// The subscriptions on the <see cref="Thing"/>s that are currently rendered as nodes, so that renaming or
+        /// deprecating a displayed <see cref="Thing"/> refreshes the diagram. They are replaced on every recompute.
+        /// </summary>
+        private readonly CompositeDisposable nodeSubscriptions = new CompositeDisposable();
 
         /// <summary>
         /// Backing field for <see cref="SelectedRootThing"/>
@@ -554,6 +561,15 @@ namespace CDP4DiagramEditor.ViewModels
         {
             if (dropInfo.Payload is Thing thing && this.IsDroppableRoot(thing))
             {
+                // dropping a thing that was excluded earlier is an explicit request to see it, so the exclusion is
+                // lifted rather than silently swallowing the drop
+                var excluded = this.ExcludedThings.FirstOrDefault(x => x.Iid == thing.Iid);
+
+                if (excluded != null)
+                {
+                    this.ExcludedThings.Remove(excluded);
+                }
+
                 this.RootThings.Add(thing);
                 this.ComputeGraph();
             }
@@ -603,6 +619,8 @@ namespace CDP4DiagramEditor.ViewModels
 
             this.Edges.Clear();
             this.Edges.AddRange(graph.Edges.Select(x => new TraceabilityEdgeViewModel(x, nodeLevels)));
+
+            this.SubscribeToNodes(graph.Nodes.Select(x => x.Thing));
 
             this.IsMaxNodeCountReached = graph.MaxNodeCountReached;
 
@@ -813,10 +831,31 @@ namespace CDP4DiagramEditor.ViewModels
         }
 
         /// <summary>
+        /// Replaces the subscriptions on the <see cref="Thing"/>s that are rendered as nodes, so that renaming or
+        /// deprecating one of them refreshes the diagram
+        /// </summary>
+        /// <param name="things">The <see cref="Thing"/>s that are currently rendered</param>
+        private void SubscribeToNodes(IEnumerable<Thing> things)
+        {
+            this.nodeSubscriptions.Clear();
+
+            foreach (var thing in things)
+            {
+                this.nodeSubscriptions.Add(
+                    this.Session.CDPMessageBus.Listen<ObjectChangedEvent>(thing)
+                        .Where(objectChange => objectChange.EventKind != EventKind.Added)
+                        .ObserveOn(RxApp.MainThreadScheduler)
+                        .Subscribe(_ => this.ComputeGraph()));
+            }
+        }
+
+        /// <summary>
         /// Adds the message bus subscriptions that keep the graph in sync with the model
         /// </summary>
         private void AddTraceabilitySubscriptions()
         {
+            this.Disposables.Add(this.nodeSubscriptions);
+
             foreach (var relationshipType in new[] { typeof(BinaryRelationship), typeof(MultiRelationship) })
             {
                 this.Disposables.Add(

--- a/CDP4DiagramEditor/ViewModels/RelationshipTraceabilityViewModel.cs
+++ b/CDP4DiagramEditor/ViewModels/RelationshipTraceabilityViewModel.cs
@@ -1,0 +1,1039 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipTraceabilityViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reactive;
+    using System.Reactive.Linq;
+    using System.Threading.Tasks;
+    using System.Windows;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.Helpers;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition;
+    using CDP4Composition.DragDrop;
+    using CDP4Composition.Exceptions;
+    using CDP4Composition.Mvvm;
+    using CDP4Composition.Mvvm.Types;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Events;
+    using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.PluginSettingService;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+
+    using CDP4DiagramEditor.Behaviors;
+    using CDP4DiagramEditor.Helpers;
+    using CDP4DiagramEditor.Settings;
+
+    using DevExpress.Diagram.Core;
+    using DevExpress.Xpf.Diagram;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// The view-model of the relationship traceability diagram panel: an ephemeral, read-only diagram of the
+    /// <see cref="Relationship"/>s reachable from a configurable set of roots, built by the
+    /// <see cref="RelationshipGraphBuilder"/>. Nothing on this panel is written to the model.
+    /// </summary>
+    public class RelationshipTraceabilityViewModel : BrowserViewModelBase<Iteration>, IPanelViewModel, IDropTarget
+    {
+        /// <summary>
+        /// The Panel Caption
+        /// </summary>
+        private const string PanelCaption = "Relationship Traceability";
+
+        /// <summary>
+        /// A value indicating whether the view-model finished initializing, used to keep the construction-time
+        /// property assignments from triggering a recompute per property
+        /// </summary>
+        private bool isInitialized;
+
+        /// <summary>
+        /// The cached <see cref="RelationshipGraphBuilder"/>, invalidated when a relationship changes so the
+        /// relationship indexes are not rebuilt on every configuration change
+        /// </summary>
+        private RelationshipGraphBuilder builder;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedRootThing"/>
+        /// </summary>
+        private Thing selectedRootThing;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedRootClassKinds"/>
+        /// </summary>
+        private List<ClassKind> selectedRootClassKinds = new List<ClassKind>();
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedRootCategories"/>
+        /// </summary>
+        private List<Category> selectedRootCategories = new List<Category>();
+
+        /// <summary>
+        /// Backing field for <see cref="DepthDown"/>
+        /// </summary>
+        private int depthDown = 2;
+
+        /// <summary>
+        /// Backing field for <see cref="DepthUp"/>
+        /// </summary>
+        private int depthUp;
+
+        /// <summary>
+        /// Backing field for <see cref="MaxNodes"/>
+        /// </summary>
+        private int maxNodes = 300;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedDefaultLevelCategories"/>
+        /// </summary>
+        private List<Category> selectedDefaultLevelCategories = new List<Category>();
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedDefaultDirection"/>
+        /// </summary>
+        private TraceabilityDirectionOption selectedDefaultDirection = TraceabilityDirectionOption.All[0];
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedExcludedThing"/>
+        /// </summary>
+        private Thing selectedExcludedThing;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedNode"/>
+        /// </summary>
+        private TraceabilityNodeViewModel selectedNode;
+
+        /// <summary>
+        /// Backing field for <see cref="LayoutDirection"/>
+        /// </summary>
+        private Direction layoutDirection = Direction.Down;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedLevelFilterRow"/>
+        /// </summary>
+        private TraceabilityLevelFilterRowViewModel selectedLevelFilterRow;
+
+        /// <summary>
+        /// Backing field for <see cref="IsMaxNodeCountReached"/>
+        /// </summary>
+        private bool isMaxNodeCountReached;
+
+        /// <summary>
+        /// Backing field for <see cref="StatusMessage"/>
+        /// </summary>
+        private string statusMessage;
+
+        /// <summary>
+        /// Backing field for <see cref="ConfigurationName"/>
+        /// </summary>
+        private string configurationName;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedConfiguration"/>
+        /// </summary>
+        private TraceabilityConfiguration selectedConfiguration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipTraceabilityViewModel"/> class
+        /// </summary>
+        /// <param name="iteration">The <see cref="Iteration"/> whose relationships are visualized</param>
+        /// <param name="session">The <see cref="ISession"/></param>
+        /// <param name="thingDialogNavigationService">The <see cref="IThingDialogNavigationService"/></param>
+        /// <param name="panelNavigationService">The <see cref="IPanelNavigationService"/></param>
+        /// <param name="dialogNavigationService">The <see cref="IDialogNavigationService"/></param>
+        /// <param name="pluginSettingsService">The <see cref="IPluginSettingsService"/></param>
+        public RelationshipTraceabilityViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        {
+            this.Caption = $"{PanelCaption}, iteration_{this.Thing.IterationSetup.IterationNumber}";
+            this.ToolTip = $"{((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name}\n{this.Thing.IDalUri}\n{this.Session.ActivePerson.Name}";
+
+            this.RootThings = new ReactiveList<Thing>();
+            this.ExcludedThings = new ReactiveList<Thing>();
+            this.Nodes = new ReactiveList<TraceabilityNodeViewModel>();
+            this.Edges = new ReactiveList<TraceabilityEdgeViewModel>();
+            this.LevelFilterRows = new ReactiveList<TraceabilityLevelFilterRowViewModel>();
+            this.PossibleCategories = new ReactiveList<Category>();
+            this.PossibleRelationshipCategories = new ReactiveList<Category>();
+            this.PossibleClassKinds = new ReactiveList<ClassKind>();
+            this.SavedConfigurations = new ReactiveList<TraceabilityConfiguration>();
+
+            this.PopulatePossibleValues();
+            this.LoadSavedConfigurations();
+
+            this.InitializeTraceabilityCommands();
+            this.AddTraceabilitySubscriptions();
+
+            this.isInitialized = true;
+            this.ComputeGraph();
+        }
+
+        /// <summary>
+        /// Gets or sets the dock layout group target name to attach this panel to on opening
+        /// </summary>
+        public string TargetName { get; set; } = LayoutGroupNames.DocumentContainer;
+
+        /// <summary>
+        /// Gets the explicitly picked root <see cref="Thing"/>s, populated by dropping things onto the diagram
+        /// </summary>
+        public ReactiveList<Thing> RootThings { get; }
+
+        /// <summary>
+        /// Gets the nodes of the rendered graph
+        /// </summary>
+        public ReactiveList<TraceabilityNodeViewModel> Nodes { get; }
+
+        /// <summary>
+        /// Gets the connectors of the rendered graph
+        /// </summary>
+        public ReactiveList<TraceabilityEdgeViewModel> Edges { get; }
+
+        /// <summary>
+        /// Gets the per-level overrides of the default relationship filter
+        /// </summary>
+        public ReactiveList<TraceabilityLevelFilterRowViewModel> LevelFilterRows { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Category"/>s defined in the open reference data libraries
+        /// </summary>
+        public ReactiveList<Category> PossibleCategories { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Category"/>s that are permissible on a <see cref="BinaryRelationship"/> or
+        /// <see cref="MultiRelationship"/>
+        /// </summary>
+        public ReactiveList<Category> PossibleRelationshipCategories { get; }
+
+        /// <summary>
+        /// Gets the categorizable <see cref="ClassKind"/>s the root set and the node filter may be scoped to
+        /// </summary>
+        public ReactiveList<ClassKind> PossibleClassKinds { get; }
+
+        /// <summary>
+        /// Gets the saved <see cref="TraceabilityConfiguration"/> presets
+        /// </summary>
+        public ReactiveList<TraceabilityConfiguration> SavedConfigurations { get; }
+
+        /// <summary>
+        /// Gets or sets the root <see cref="Thing"/> selected in the roots list, used by the remove command
+        /// </summary>
+        public Thing SelectedRootThing
+        {
+            get => this.selectedRootThing;
+            set => this.RaiseAndSetIfChanged(ref this.selectedRootThing, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ClassKind"/>s that define the root set, or empty when the roots are only the
+        /// explicitly dropped <see cref="Thing"/>s
+        /// </summary>
+        public List<ClassKind> SelectedRootClassKinds
+        {
+            get => this.selectedRootClassKinds;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.selectedRootClassKinds, value ?? new List<ClassKind>());
+                this.PopulatePossibleCategories();
+                this.ComputeGraph();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Category"/>s the <see cref="SelectedRootClassKinds"/> root set is filtered by
+        /// </summary>
+        public List<Category> SelectedRootCategories
+        {
+            get => this.selectedRootCategories;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.selectedRootCategories, value ?? new List<Category>());
+                this.ComputeGraph();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of levels that are traversed downward
+        /// </summary>
+        public int DepthDown
+        {
+            get => this.depthDown;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.depthDown, value);
+                this.ComputeGraph();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of levels that are traversed upward
+        /// </summary>
+        public int DepthUp
+        {
+            get => this.depthUp;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.depthUp, value);
+                this.ComputeGraph();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of nodes that the diagram may contain
+        /// </summary>
+        public int MaxNodes
+        {
+            get => this.maxNodes;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.maxNodes, value);
+                this.ComputeGraph();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Category"/>s that a relationship must be a member of to be followed, at any
+        /// level without an override. Empty means every relationship is followed.
+        /// </summary>
+        public List<Category> SelectedDefaultLevelCategories
+        {
+            get => this.selectedDefaultLevelCategories;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.selectedDefaultLevelCategories, value ?? new List<Category>());
+                this.ComputeGraph();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the node currently selected on the diagram, used by the exclude command
+        /// </summary>
+        public TraceabilityNodeViewModel SelectedNode
+        {
+            get => this.selectedNode;
+            set => this.RaiseAndSetIfChanged(ref this.selectedNode, value);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Thing"/>s that were excluded from the diagram by the user
+        /// </summary>
+        public ReactiveList<Thing> ExcludedThings { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Thing"/> selected in the excluded list, used by the restore command
+        /// </summary>
+        public Thing SelectedExcludedThing
+        {
+            get => this.selectedExcludedThing;
+            set => this.RaiseAndSetIfChanged(ref this.selectedExcludedThing, value);
+        }
+
+        /// <summary>
+        /// Gets or sets how relationship arrows are followed at levels without an override; the first
+        /// <see cref="TraceabilityDirectionOption"/> stands for the natural direction of the expansion. Overriding
+        /// this allows a hierarchy whose relationship arrows change direction along the chain to be traversed in one
+        /// pass.
+        /// </summary>
+        public TraceabilityDirectionOption SelectedDefaultDirection
+        {
+            get => this.selectedDefaultDirection;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.selectedDefaultDirection, value ?? TraceabilityDirectionOption.All[0]);
+                this.ComputeGraph();
+            }
+        }
+
+        /// <summary>
+        /// Gets the traversal directions the user may pick from
+        /// </summary>
+        public IReadOnlyList<TraceabilityDirectionOption> PossibleDirections => TraceabilityDirectionOption.All;
+
+        /// <summary>
+        /// Gets or sets the orientation of the automatic layout
+        /// </summary>
+        public Direction LayoutDirection
+        {
+            get => this.layoutDirection;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.layoutDirection, value);
+                this.Behavior?.ApplyLayout();
+            }
+        }
+
+        /// <summary>
+        /// Gets the orientations the automatic layout can be applied in
+        /// </summary>
+        public IReadOnlyList<TraceabilityLayoutOption> PossibleLayoutDirections { get; } = new List<TraceabilityLayoutOption>
+        {
+            new TraceabilityLayoutOption(Direction.Down, "Top-down"),
+            new TraceabilityLayoutOption(Direction.Up, "Bottom-up"),
+            new TraceabilityLayoutOption(Direction.Right, "Left to right"),
+            new TraceabilityLayoutOption(Direction.Left, "Right to left")
+        };
+
+        /// <summary>
+        /// Gets or sets the <see cref="ITraceabilityDiagramBehavior"/> that the attached diagram control injects, used
+        /// to apply the layout and to export the diagram
+        /// </summary>
+        public ITraceabilityDiagramBehavior Behavior { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selected per-level override row, used by the remove command
+        /// </summary>
+        public TraceabilityLevelFilterRowViewModel SelectedLevelFilterRow
+        {
+            get => this.selectedLevelFilterRow;
+            set => this.RaiseAndSetIfChanged(ref this.selectedLevelFilterRow, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the last traversal was cut short by <see cref="MaxNodes"/>, in which case
+        /// the diagram is incomplete and a warning is shown
+        /// </summary>
+        public bool IsMaxNodeCountReached
+        {
+            get => this.isMaxNodeCountReached;
+            private set => this.RaiseAndSetIfChanged(ref this.isMaxNodeCountReached, value);
+        }
+
+        /// <summary>
+        /// Gets the status message describing the rendered graph
+        /// </summary>
+        public string StatusMessage
+        {
+            get => this.statusMessage;
+            private set => this.RaiseAndSetIfChanged(ref this.statusMessage, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the name under which the current configuration is saved
+        /// </summary>
+        public string ConfigurationName
+        {
+            get => this.configurationName;
+            set => this.RaiseAndSetIfChanged(ref this.configurationName, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the selected saved configuration. Setting it applies the preset to the panel.
+        /// </summary>
+        public TraceabilityConfiguration SelectedConfiguration
+        {
+            get => this.selectedConfiguration;
+            set
+            {
+                // the editor re-commits an unchanged selection on focus changes; re-applying then would silently
+                // revert any tweak the user made since selecting the preset
+                var changed = !ReferenceEquals(this.selectedConfiguration, value);
+
+                this.RaiseAndSetIfChanged(ref this.selectedConfiguration, value);
+
+                if (changed)
+                {
+                    this.ApplyConfiguration(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the command that recomputes the graph
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> RefreshCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that removes <see cref="SelectedRootThing"/> from <see cref="RootThings"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> RemoveRootThingCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that clears <see cref="RootThings"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> ClearRootThingsCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that adds a per-level override row
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> AddLevelFilterRowCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that removes <see cref="SelectedLevelFilterRow"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> RemoveLevelFilterRowCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that saves the current configuration under <see cref="ConfigurationName"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> SaveConfigurationCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that deletes <see cref="SelectedConfiguration"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> DeleteConfigurationCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command invoked when the diagram selection changes; it publishes the selected node's
+        /// <see cref="Thing"/> so the property grid shows it
+        /// </summary>
+        public ReactiveCommand<object, Unit> DiagramSelectionChangedCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that excludes <see cref="SelectedNode"/> from the diagram; everything that is only
+        /// reachable through it disappears with it
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> ExcludeSelectedNodeCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that restores <see cref="SelectedExcludedThing"/> to the diagram
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> RestoreExcludedThingCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that clears all exclusions
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> ResetExclusionsCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that exports the diagram; its parameter is the name of a
+        /// <see cref="DiagramExportFormat"/> value (PNG, JPEG or SVG)
+        /// </summary>
+        public ReactiveCommand<string, Unit> ExportCommand { get; private set; }
+
+        /// <summary>
+        /// Updates the current drag state
+        /// </summary>
+        /// <param name="dropInfo">Information about the drag operation</param>
+        public void DragOver(IDropInfo dropInfo)
+        {
+            if (dropInfo.Payload is Thing thing && this.IsDroppableRoot(thing))
+            {
+                dropInfo.Effects = DragDropEffects.Copy;
+                return;
+            }
+
+            dropInfo.Effects = DragDropEffects.None;
+        }
+
+        /// <summary>
+        /// Performs the drop operation: the dropped <see cref="Thing"/> becomes an additional root
+        /// </summary>
+        /// <param name="dropInfo">Information about the drop operation</param>
+        /// <returns>An awaitable <see cref="Task"/></returns>
+        public Task Drop(IDropInfo dropInfo)
+        {
+            if (dropInfo.Payload is Thing thing && this.IsDroppableRoot(thing))
+            {
+                this.RootThings.Add(thing);
+                this.ComputeGraph();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asserts whether a dragged <see cref="Thing"/> may become a root: it must belong to the iteration this panel
+        /// shows and not be a root already
+        /// </summary>
+        /// <param name="thing">The dragged <see cref="Thing"/></param>
+        /// <returns>true when the <see cref="Thing"/> may become a root</returns>
+        private bool IsDroppableRoot(Thing thing)
+        {
+            return thing.GetContainerOfType<Iteration>()?.Iid == this.Thing.Iid && this.RootThings.All(x => x.Iid != thing.Iid);
+        }
+
+        /// <summary>
+        /// Recomputes the graph from the current configuration and repopulates <see cref="Nodes"/> and
+        /// <see cref="Edges"/>
+        /// </summary>
+        public void ComputeGraph()
+        {
+            if (!this.isInitialized)
+            {
+                return;
+            }
+
+            // the node view-models are about to be recreated, so any diagram selection becomes stale
+            this.SelectedNode = null;
+
+            var roots = new List<Thing>(this.RootThings);
+
+            if (this.SelectedRootClassKinds.Any())
+            {
+                roots.AddRange(this.QueryRootsByClassKindAndCategory());
+            }
+
+            this.builder = this.builder ?? new RelationshipGraphBuilder(this.Thing);
+            var graph = this.builder.Build(roots, this.BuildConfiguration());
+
+            this.Nodes.Clear();
+            this.Nodes.AddRange(graph.Nodes.Select(x => new TraceabilityNodeViewModel(x)));
+
+            var nodeLevels = graph.Nodes.ToDictionary(x => x.Thing.Iid, x => x.Level);
+
+            this.Edges.Clear();
+            this.Edges.AddRange(graph.Edges.Select(x => new TraceabilityEdgeViewModel(x, nodeLevels)));
+
+            this.IsMaxNodeCountReached = graph.MaxNodeCountReached;
+
+            var exclusionSuffix = this.ExcludedThings.Any() ? $", {this.ExcludedThings.Count} excluded" : string.Empty;
+            this.StatusMessage = $"{graph.Nodes.Count} nodes, {graph.Edges.Count} relationships{exclusionSuffix}";
+        }
+
+        /// <summary>
+        /// Queries the <see cref="Thing"/>s of the current iteration that match <see cref="SelectedRootClassKinds"/>
+        /// and <see cref="SelectedRootCategories"/>
+        /// </summary>
+        /// <returns>The matching <see cref="Thing"/>s</returns>
+        private IEnumerable<Thing> QueryRootsByClassKindAndCategory()
+        {
+            var candidates = this.Session.Assembler.Cache
+                .Where(x => x.Key.Iteration.HasValue && x.Key.Iteration.Value == this.Thing.Iid)
+                .Select(x => x.Value.Value)
+                .Where(x => this.SelectedRootClassKinds.Contains(x.ClassKind));
+
+            if (!this.SelectedRootCategories.Any())
+            {
+                return candidates;
+            }
+
+            var filter = new RelationshipGraphFilter();
+            filter.Categories.AddRange(this.SelectedRootCategories);
+
+            return candidates.Where(filter.IsMatch);
+        }
+
+        /// <summary>
+        /// Builds the <see cref="RelationshipGraphConfiguration"/> from the current state of the panel
+        /// </summary>
+        /// <returns>The <see cref="RelationshipGraphConfiguration"/></returns>
+        private RelationshipGraphConfiguration BuildConfiguration()
+        {
+            var configuration = new RelationshipGraphConfiguration
+            {
+                DepthDown = this.DepthDown,
+                DepthUp = this.DepthUp,
+                MaxNodes = this.MaxNodes,
+                DefaultLevelFilter = BuildFilter(this.SelectedDefaultLevelCategories, this.SelectedDefaultDirection.Direction)
+            };
+
+            foreach (var excludedThing in this.ExcludedThings)
+            {
+                configuration.ExcludedThings.Add(excludedThing.Iid);
+            }
+
+            foreach (var row in this.LevelFilterRows.Where(x => x.IsActive))
+            {
+                configuration.LevelFilterOverrides[row.Level] = BuildFilter(row.SelectedCategories, row.Direction);
+            }
+
+            return configuration;
+        }
+
+        /// <summary>
+        /// Builds a <see cref="RelationshipGraphFilter"/> from a set of <see cref="Category"/>s and a traversal
+        /// direction
+        /// </summary>
+        /// <param name="categories">The <see cref="Category"/> facet</param>
+        /// <param name="direction">The traversal direction, or null for the natural direction</param>
+        /// <returns>The <see cref="RelationshipGraphFilter"/>, or null when both facets are empty</returns>
+        private static RelationshipGraphFilter BuildFilter(IReadOnlyCollection<Category> categories, RelationshipTraversalDirection? direction)
+        {
+            if (categories.Count == 0 && direction == null)
+            {
+                return null;
+            }
+
+            var filter = new RelationshipGraphFilter { Direction = direction };
+            filter.Categories.AddRange(categories);
+
+            return filter;
+        }
+
+        /// <summary>
+        /// Populates the possible <see cref="Category"/> and <see cref="ClassKind"/> pickers from the open reference
+        /// data libraries
+        /// </summary>
+        private void PopulatePossibleValues()
+        {
+            this.PossibleRelationshipCategories.Clear();
+
+            this.PossibleRelationshipCategories.AddRange(
+                this.QueryOpenRdlCategories()
+                    .Where(x => x.PermissibleClass.Contains(ClassKind.BinaryRelationship) || x.PermissibleClass.Contains(ClassKind.MultiRelationship)));
+
+            this.PossibleClassKinds.Clear();
+
+            this.PossibleClassKinds.AddRange(
+                DiagramEditorPluginSettings.DefaultClassKinds
+                    .Where(x => TypeInitializer.Initialize(x) is ICategorizableThing)
+                    .OrderBy(x => x.ToString()));
+
+            this.PopulatePossibleCategories();
+        }
+
+        /// <summary>
+        /// Populates <see cref="PossibleCategories"/> with the <see cref="Category"/>s that are permissible on the
+        /// selected root <see cref="ClassKind"/>s, or on any offered <see cref="ClassKind"/> when none is selected,
+        /// mirroring the Relationship Matrix source configuration
+        /// </summary>
+        private void PopulatePossibleCategories()
+        {
+            var applicableKinds = this.SelectedRootClassKinds.Any()
+                ? (IReadOnlyCollection<ClassKind>)this.SelectedRootClassKinds
+                : this.PossibleClassKinds.ToList();
+
+            this.PossibleCategories.Clear();
+
+            this.PossibleCategories.AddRange(
+                this.QueryOpenRdlCategories().Where(x => x.PermissibleClass.Intersect(applicableKinds).Any()));
+        }
+
+        /// <summary>
+        /// Queries the <see cref="Category"/>s defined in the open reference data libraries, ordered by name
+        /// </summary>
+        /// <returns>The <see cref="Category"/>s</returns>
+        private List<Category> QueryOpenRdlCategories()
+        {
+            return this.Session.OpenReferenceDataLibraries
+                .SelectMany(x => x.DefinedCategory)
+                .Distinct()
+                .OrderBy(x => x.Name)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="ReactiveCommand{TParam,TResult}"/>s of this panel
+        /// </summary>
+        private void InitializeTraceabilityCommands()
+        {
+            this.RefreshCommand = ReactiveCommandCreator.Create(this.ComputeGraph);
+
+            this.RemoveRootThingCommand = ReactiveCommandCreator.Create(
+                () =>
+                {
+                    this.RootThings.Remove(this.SelectedRootThing);
+                    this.ComputeGraph();
+                },
+                this.WhenAnyValue(x => x.SelectedRootThing).Select(x => x != null));
+
+            this.ClearRootThingsCommand = ReactiveCommandCreator.Create(
+                () =>
+                {
+                    this.RootThings.Clear();
+                    this.ComputeGraph();
+                });
+
+            this.AddLevelFilterRowCommand = ReactiveCommandCreator.Create(
+                () => this.LevelFilterRows.Add(new TraceabilityLevelFilterRowViewModel(this.PossibleRelationshipCategories, this.ComputeGraph)));
+
+            this.RemoveLevelFilterRowCommand = ReactiveCommandCreator.Create(
+                () =>
+                {
+                    this.LevelFilterRows.Remove(this.SelectedLevelFilterRow);
+                    this.ComputeGraph();
+                },
+                this.WhenAnyValue(x => x.SelectedLevelFilterRow).Select(x => x != null));
+
+            this.SaveConfigurationCommand = ReactiveCommandCreator.Create(
+                this.SaveConfiguration,
+                this.WhenAnyValue(x => x.ConfigurationName).Select(x => !string.IsNullOrWhiteSpace(x)));
+
+            this.DeleteConfigurationCommand = ReactiveCommandCreator.Create(
+                this.DeleteConfiguration,
+                this.WhenAnyValue(x => x.SelectedConfiguration).Select(x => x != null));
+
+            this.DiagramSelectionChangedCommand = ReactiveCommandCreator.Create<object>(this.OnDiagramSelectionChanged);
+
+            this.ExcludeSelectedNodeCommand = ReactiveCommandCreator.Create(
+                () =>
+                {
+                    if (this.ExcludedThings.All(x => x.Iid != this.SelectedNode.Thing.Iid))
+                    {
+                        this.ExcludedThings.Add(this.SelectedNode.Thing);
+                    }
+
+                    this.ComputeGraph();
+                },
+                this.WhenAnyValue(x => x.SelectedNode).Select(x => x != null));
+
+            this.RestoreExcludedThingCommand = ReactiveCommandCreator.Create(
+                () =>
+                {
+                    this.ExcludedThings.Remove(this.SelectedExcludedThing);
+                    this.ComputeGraph();
+                },
+                this.WhenAnyValue(x => x.SelectedExcludedThing).Select(x => x != null));
+
+            this.ResetExclusionsCommand = ReactiveCommandCreator.Create(
+                () =>
+                {
+                    this.ExcludedThings.Clear();
+                    this.ComputeGraph();
+                });
+
+            this.ExportCommand = ReactiveCommandCreator.Create<string>(
+                formatName =>
+                {
+                    if (Enum.TryParse(formatName, true, out DiagramExportFormat format))
+                    {
+                        this.Behavior?.Export(format);
+                    }
+                });
+        }
+
+        /// <summary>
+        /// Adds the message bus subscriptions that keep the graph in sync with the model
+        /// </summary>
+        private void AddTraceabilitySubscriptions()
+        {
+            foreach (var relationshipType in new[] { typeof(BinaryRelationship), typeof(MultiRelationship) })
+            {
+                this.Disposables.Add(
+                    this.Session.CDPMessageBus.Listen<ObjectChangedEvent>(relationshipType)
+                        .ObserveOn(RxApp.MainThreadScheduler)
+                        .Subscribe(_ =>
+                        {
+                            this.builder = null;
+                            this.ComputeGraph();
+                        }));
+            }
+
+            this.Disposables.Add(
+                this.Session.CDPMessageBus.Listen<ObjectChangedEvent>(typeof(Category))
+                    .ObserveOn(RxApp.MainThreadScheduler)
+                    .Subscribe(_ =>
+                    {
+                        this.PopulatePossibleValues();
+                        this.ComputeGraph();
+                    }));
+        }
+
+        /// <summary>
+        /// Handles a selection change of the diagram control by publishing the selected node's <see cref="Thing"/> on
+        /// the message bus, so the property grid shows it
+        /// </summary>
+        /// <param name="eventArgs">The event arguments of the selection change</param>
+        private void OnDiagramSelectionChanged(object eventArgs)
+        {
+            if (!((eventArgs as DiagramSelectionChangedEventArgs)?.Source is DiagramControl diagramControl))
+            {
+                return;
+            }
+
+            var node = diagramControl.SelectedItems
+                .OfType<DiagramContentItem>()
+                .Select(x => x.Content)
+                .OfType<TraceabilityNodeViewModel>()
+                .FirstOrDefault();
+
+            this.SelectedNode = node;
+
+            if (node != null)
+            {
+                this.Session.CDPMessageBus.SendMessage(new SelectedThingChangedEvent(node.Thing, this.Session));
+            }
+        }
+
+        /// <summary>
+        /// Reads the <see cref="DiagramEditorPluginSettings"/>, creating the settings file with defaults on first use
+        /// </summary>
+        /// <returns>The <see cref="DiagramEditorPluginSettings"/></returns>
+        private DiagramEditorPluginSettings ReadOrInitializeSettings()
+        {
+            try
+            {
+                return this.PluginSettingsService.Read<DiagramEditorPluginSettings>();
+            }
+            catch (PluginSettingsException)
+            {
+                // first use: no settings file exists yet, create it with defaults
+                var settings = new DiagramEditorPluginSettings();
+                this.PluginSettingsService.Write(settings);
+
+                return settings;
+            }
+        }
+
+        /// <summary>
+        /// Loads the saved <see cref="TraceabilityConfiguration"/> presets from the plugin settings
+        /// </summary>
+        private void LoadSavedConfigurations()
+        {
+            var settings = this.ReadOrInitializeSettings();
+
+            this.SavedConfigurations.Clear();
+            this.SavedConfigurations.AddRange(settings.SavedConfigurations.OfType<TraceabilityConfiguration>());
+        }
+
+        /// <summary>
+        /// Saves the current configuration under <see cref="ConfigurationName"/>, replacing an existing preset with
+        /// the same name
+        /// </summary>
+        private void SaveConfiguration()
+        {
+            this.ConfigurationName = this.ConfigurationName.Trim();
+
+            var configuration = new TraceabilityConfiguration
+            {
+                Name = this.ConfigurationName,
+                RootClassKinds = this.SelectedRootClassKinds.ToList(),
+                RootCategories = this.SelectedRootCategories.Select(x => x.Iid).ToList(),
+                DepthDown = this.DepthDown,
+                DepthUp = this.DepthUp,
+                MaxNodes = this.MaxNodes,
+                LayoutDirection = this.LayoutDirection,
+                DefaultLevelCategories = this.SelectedDefaultLevelCategories.Select(x => x.Iid).ToList(),
+                DefaultDirection = this.SelectedDefaultDirection.Direction,
+                LevelOverrides = this.LevelFilterRows
+                    .Where(x => x.IsActive)
+                    .Select(x => new TraceabilityLevelOverride { Level = x.Level, Direction = x.Direction, Categories = x.SelectedCategories.Select(c => c.Iid).ToList() })
+                    .ToList()
+            };
+
+            var settings = this.ReadOrInitializeSettings();
+
+            var existing = settings.SavedConfigurations
+                .OfType<TraceabilityConfiguration>()
+                .FirstOrDefault(x => x.Name == configuration.Name);
+
+            if (existing != null)
+            {
+                configuration.Id = existing.Id;
+                settings.SavedConfigurations.Remove(existing);
+            }
+
+            settings.SavedConfigurations.Add(configuration);
+            this.PluginSettingsService.Write(settings);
+
+            this.LoadSavedConfigurations();
+            this.selectedConfiguration = this.SavedConfigurations.FirstOrDefault(x => x.Id == configuration.Id);
+            this.RaisePropertyChanged(nameof(this.SelectedConfiguration));
+        }
+
+        /// <summary>
+        /// Deletes <see cref="SelectedConfiguration"/> from the plugin settings
+        /// </summary>
+        private void DeleteConfiguration()
+        {
+            var settings = this.ReadOrInitializeSettings();
+
+            var existing = settings.SavedConfigurations
+                .OfType<TraceabilityConfiguration>()
+                .FirstOrDefault(x => x.Id == this.SelectedConfiguration.Id);
+
+            if (existing != null)
+            {
+                settings.SavedConfigurations.Remove(existing);
+                this.PluginSettingsService.Write(settings);
+            }
+
+            this.selectedConfiguration = null;
+            this.RaisePropertyChanged(nameof(this.SelectedConfiguration));
+            this.LoadSavedConfigurations();
+        }
+
+        /// <summary>
+        /// Applies a saved <see cref="TraceabilityConfiguration"/> to the panel and recomputes the graph once
+        /// </summary>
+        /// <param name="configuration">The <see cref="TraceabilityConfiguration"/> to apply, or null</param>
+        private void ApplyConfiguration(TraceabilityConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                return;
+            }
+
+            this.isInitialized = false;
+
+            try
+            {
+                this.ConfigurationName = configuration.Name;
+                this.SelectedRootClassKinds = configuration.RootClassKinds.ToList();
+                this.SelectedRootCategories = this.ResolveCategories(configuration.RootCategories);
+                this.DepthDown = configuration.DepthDown;
+                this.DepthUp = configuration.DepthUp;
+                this.MaxNodes = configuration.MaxNodes;
+                this.LayoutDirection = configuration.LayoutDirection;
+                this.SelectedDefaultLevelCategories = this.ResolveCategories(configuration.DefaultLevelCategories);
+                this.SelectedDefaultDirection = ResolveDirectionOption(configuration.DefaultDirection);
+
+                // ad-hoc exclusions would silently distort the applied preset
+                this.ExcludedThings.Clear();
+
+                this.LevelFilterRows.Clear();
+
+                foreach (var levelOverride in configuration.LevelOverrides)
+                {
+                    this.LevelFilterRows.Add(new TraceabilityLevelFilterRowViewModel(this.PossibleRelationshipCategories, this.ComputeGraph)
+                    {
+                        Level = levelOverride.Level,
+                        SelectedDirection = ResolveDirectionOption(levelOverride.Direction),
+                        SelectedCategories = this.ResolveCategories(levelOverride.Categories)
+                    });
+                }
+            }
+            finally
+            {
+                this.isInitialized = true;
+            }
+
+            this.ComputeGraph();
+        }
+
+        /// <summary>
+        /// Resolves a persisted traversal direction to its <see cref="TraceabilityDirectionOption"/>
+        /// </summary>
+        /// <param name="direction">The persisted direction, or null for the natural direction</param>
+        /// <returns>The matching <see cref="TraceabilityDirectionOption"/></returns>
+        private static TraceabilityDirectionOption ResolveDirectionOption(RelationshipTraversalDirection? direction)
+        {
+            return TraceabilityDirectionOption.All.First(x => x.Direction == direction);
+        }
+
+        /// <summary>
+        /// Resolves persisted <see cref="Category"/> identifiers against the open reference data libraries. Categories
+        /// that are not present in them are silently dropped.
+        /// </summary>
+        /// <param name="iids">The persisted <see cref="Thing.Iid"/>s</param>
+        /// <returns>The resolved <see cref="Category"/>s</returns>
+        private List<Category> ResolveCategories(IEnumerable<Guid> iids)
+        {
+            var openRdlCategories = this.QueryOpenRdlCategories();
+
+            return iids.Select(iid => openRdlCategories.FirstOrDefault(x => x.Iid == iid))
+                .Where(x => x != null)
+                .ToList();
+        }
+    }
+}

--- a/CDP4DiagramEditor/ViewModels/TraceabilityDirectionOption.cs
+++ b/CDP4DiagramEditor/ViewModels/TraceabilityDirectionOption.cs
@@ -1,0 +1,70 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityDirectionOption.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.ViewModels
+{
+    using System.Collections.Generic;
+
+    using CDP4DiagramEditor.Helpers;
+
+    /// <summary>
+    /// Represents a selectable <see cref="RelationshipTraversalDirection"/> of a traversal level, where null stands
+    /// for the natural direction of the expansion
+    /// </summary>
+    public class TraceabilityDirectionOption
+    {
+        /// <summary>
+        /// The options offered by every direction picker
+        /// </summary>
+        public static readonly IReadOnlyList<TraceabilityDirectionOption> All = new List<TraceabilityDirectionOption>
+        {
+            new TraceabilityDirectionOption(null, "Automatic (down: along, up: against)"),
+            new TraceabilityDirectionOption(RelationshipTraversalDirection.AlongArrows, "Along arrows (source to target)"),
+            new TraceabilityDirectionOption(RelationshipTraversalDirection.AgainstArrows, "Against arrows (target to source)"),
+            new TraceabilityDirectionOption(RelationshipTraversalDirection.Both, "Both directions")
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceabilityDirectionOption"/> class
+        /// </summary>
+        /// <param name="direction">The <see cref="RelationshipTraversalDirection"/>, or null for the natural direction</param>
+        /// <param name="label">The label shown to the user</param>
+        public TraceabilityDirectionOption(RelationshipTraversalDirection? direction, string label)
+        {
+            this.Direction = direction;
+            this.Label = label;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="RelationshipTraversalDirection"/>, or null for the natural direction
+        /// </summary>
+        public RelationshipTraversalDirection? Direction { get; }
+
+        /// <summary>
+        /// Gets the label shown to the user
+        /// </summary>
+        public string Label { get; }
+    }
+}

--- a/CDP4DiagramEditor/ViewModels/TraceabilityEdgeViewModel.cs
+++ b/CDP4DiagramEditor/ViewModels/TraceabilityEdgeViewModel.cs
@@ -1,0 +1,112 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityEdgeViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4DiagramEditor.Helpers;
+
+    /// <summary>
+    /// Represents a <see cref="RelationshipGraphEdge"/> as a connector on the traceability diagram. The connector runs
+    /// from the shallower to the deeper traversal level, so the automatic layout stacks the levels in traversal order
+    /// even when the model arrow points the other way; <see cref="IsReversed"/> tells the view to draw the arrow head
+    /// on the begin side in that case, so the arrow always shows the true direction of the <see cref="Relationship"/>.
+    /// </summary>
+    public class TraceabilityEdgeViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceabilityEdgeViewModel"/> class
+        /// </summary>
+        /// <param name="edge">
+        /// The <see cref="RelationshipGraphEdge"/> that is represented
+        /// </param>
+        /// <param name="nodeLevels">
+        /// The traversal level of every node, keyed by <see cref="Thing.Iid"/>
+        /// </param>
+        public TraceabilityEdgeViewModel(RelationshipGraphEdge edge, IReadOnlyDictionary<Guid, int> nodeLevels)
+        {
+            this.Relationship = edge.Relationship;
+            this.IsUndirected = edge.Relationship is MultiRelationship;
+            this.Label = string.Join(", ", edge.Relationship.Category.Select(x => x.ShortName));
+
+            nodeLevels.TryGetValue(edge.Source.Iid, out var sourceLevel);
+            nodeLevels.TryGetValue(edge.Target.Iid, out var targetLevel);
+
+            if (sourceLevel <= targetLevel)
+            {
+                this.FromId = edge.Source.Iid;
+                this.ToId = edge.Target.Iid;
+                this.IsReversed = false;
+            }
+            else
+            {
+                this.FromId = edge.Target.Iid;
+                this.ToId = edge.Source.Iid;
+                this.IsReversed = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="TraceabilityNodeViewModel.Id"/> of the node the connector originates from, always the
+        /// endpoint at the shallower traversal level
+        /// </summary>
+        public Guid FromId { get; }
+
+        /// <summary>
+        /// Gets the <see cref="TraceabilityNodeViewModel.Id"/> of the node the connector points to, always the
+        /// endpoint at the deeper traversal level
+        /// </summary>
+        public Guid ToId { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the connector runs against the arrow of the <see cref="Relationship"/>, in
+        /// which case the view draws the arrow head on the begin side
+        /// </summary>
+        public bool IsReversed { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the represented <see cref="Relationship"/> is undirected, in which case no
+        /// arrow head is drawn at all
+        /// </summary>
+        public bool IsUndirected { get; }
+
+        /// <summary>
+        /// Gets the represented <see cref="Relationship"/>
+        /// </summary>
+        public Relationship Relationship { get; }
+
+        /// <summary>
+        /// Gets the label of the connector: the short names of the <see cref="Category"/>s of the represented
+        /// <see cref="Relationship"/>
+        /// </summary>
+        public string Label { get; }
+    }
+}

--- a/CDP4DiagramEditor/ViewModels/TraceabilityEdgeViewModel.cs
+++ b/CDP4DiagramEditor/ViewModels/TraceabilityEdgeViewModel.cs
@@ -36,9 +36,10 @@ namespace CDP4DiagramEditor.ViewModels
 
     /// <summary>
     /// Represents a <see cref="RelationshipGraphEdge"/> as a connector on the traceability diagram. The connector runs
-    /// from the shallower to the deeper traversal level, so the automatic layout stacks the levels in traversal order
-    /// even when the model arrow points the other way; <see cref="IsReversed"/> tells the view to draw the arrow head
-    /// on the begin side in that case, so the arrow always shows the true direction of the <see cref="Relationship"/>.
+    /// in order of ascending <see cref="RelationshipGraphNode.Level"/>, so the automatic layout stacks the upward cone
+    /// above the roots and the downward cone below them, even when the model arrow points the other way;
+    /// <see cref="IsReversed"/> then tells the view to draw the arrow head on the begin side, so the arrow keeps
+    /// showing the true direction of the <see cref="Relationship"/>.
     /// </summary>
     public class TraceabilityEdgeViewModel
     {
@@ -76,13 +77,13 @@ namespace CDP4DiagramEditor.ViewModels
 
         /// <summary>
         /// Gets the <see cref="TraceabilityNodeViewModel.Id"/> of the node the connector originates from, always the
-        /// endpoint at the shallower traversal level
+        /// endpoint with the lower <see cref="RelationshipGraphNode.Level"/>
         /// </summary>
         public Guid FromId { get; }
 
         /// <summary>
         /// Gets the <see cref="TraceabilityNodeViewModel.Id"/> of the node the connector points to, always the
-        /// endpoint at the deeper traversal level
+        /// endpoint with the higher <see cref="RelationshipGraphNode.Level"/>
         /// </summary>
         public Guid ToId { get; }
 

--- a/CDP4DiagramEditor/ViewModels/TraceabilityLayoutOption.cs
+++ b/CDP4DiagramEditor/ViewModels/TraceabilityLayoutOption.cs
@@ -1,0 +1,56 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityLayoutOption.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.ViewModels
+{
+    using DevExpress.Diagram.Core;
+
+    /// <summary>
+    /// Represents a selectable orientation of the automatic layout of the traceability diagram
+    /// </summary>
+    public class TraceabilityLayoutOption
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceabilityLayoutOption"/> class
+        /// </summary>
+        /// <param name="direction">The <see cref="DevExpress.Diagram.Core.Direction"/> of the layout</param>
+        /// <param name="label">The label shown to the user</param>
+        public TraceabilityLayoutOption(Direction direction, string label)
+        {
+            this.Direction = direction;
+            this.Label = label;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DevExpress.Diagram.Core.Direction"/> of the layout
+        /// </summary>
+        public Direction Direction { get; }
+
+        /// <summary>
+        /// Gets the label shown to the user
+        /// </summary>
+        public string Label { get; }
+    }
+}

--- a/CDP4DiagramEditor/ViewModels/TraceabilityLevelFilterRowViewModel.cs
+++ b/CDP4DiagramEditor/ViewModels/TraceabilityLevelFilterRowViewModel.cs
@@ -1,0 +1,139 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityLevelFilterRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Mvvm;
+
+    using CDP4DiagramEditor.Helpers;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Represents one per-level override row of the relationship filter of the traceability diagram: at the given
+    /// <see cref="Level"/> only relationships that are a member of one of the <see cref="SelectedCategories"/> are
+    /// followed, instead of the default filter.
+    /// </summary>
+    public class TraceabilityLevelFilterRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// The callback that notifies the owning panel that this row changed
+        /// </summary>
+        private readonly Action onChanged;
+
+        /// <summary>
+        /// Backing field for <see cref="Level"/>
+        /// </summary>
+        private int level = 1;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedCategories"/>
+        /// </summary>
+        private List<Category> selectedCategories = new List<Category>();
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedDirection"/>
+        /// </summary>
+        private TraceabilityDirectionOption selectedDirection = TraceabilityDirectionOption.All[0];
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceabilityLevelFilterRowViewModel"/> class
+        /// </summary>
+        /// <param name="possibleCategories">
+        /// The <see cref="Category"/>s the user may pick from
+        /// </param>
+        /// <param name="onChanged">
+        /// The callback that notifies the owning panel that this row changed
+        /// </param>
+        public TraceabilityLevelFilterRowViewModel(ReactiveList<Category> possibleCategories, Action onChanged)
+        {
+            this.PossibleCategories = possibleCategories;
+            this.onChanged = onChanged;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Category"/>s the user may pick from
+        /// </summary>
+        public ReactiveList<Category> PossibleCategories { get; }
+
+        /// <summary>
+        /// Gets or sets the one-based level at which this override applies
+        /// </summary>
+        public int Level
+        {
+            get => this.level;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.level, value);
+                this.onChanged?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how relationship arrows are followed at this level; the first
+        /// <see cref="TraceabilityDirectionOption"/> stands for the natural direction of the expansion
+        /// </summary>
+        public TraceabilityDirectionOption SelectedDirection
+        {
+            get => this.selectedDirection;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.selectedDirection, value ?? TraceabilityDirectionOption.All[0]);
+                this.onChanged?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Gets how relationship arrows are followed at this level, or null for the natural direction of the expansion
+        /// </summary>
+        public RelationshipTraversalDirection? Direction => this.SelectedDirection.Direction;
+
+        /// <summary>
+        /// Gets a value indicating whether this row constrains its level at all: it must have a valid level and either
+        /// a category filter or a direction override
+        /// </summary>
+        public bool IsActive => this.Level >= 1 && (this.SelectedCategories.Any() || this.Direction != null);
+
+        /// <summary>
+        /// Gets or sets the <see cref="Category"/>s that a relationship must be a member of to be followed at this
+        /// level
+        /// </summary>
+        public List<Category> SelectedCategories
+        {
+            get => this.selectedCategories;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.selectedCategories, value ?? new List<Category>());
+                this.onChanged?.Invoke();
+            }
+        }
+    }
+}

--- a/CDP4DiagramEditor/ViewModels/TraceabilityNodeViewModel.cs
+++ b/CDP4DiagramEditor/ViewModels/TraceabilityNodeViewModel.cs
@@ -1,0 +1,102 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityNodeViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.ViewModels
+{
+    using System;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+
+    using CDP4DiagramEditor.Helpers;
+
+    /// <summary>
+    /// Represents a <see cref="RelationshipGraphNode"/> as an item on the traceability diagram
+    /// </summary>
+    public class TraceabilityNodeViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceabilityNodeViewModel"/> class
+        /// </summary>
+        /// <param name="node">
+        /// The <see cref="RelationshipGraphNode"/> that is represented
+        /// </param>
+        public TraceabilityNodeViewModel(RelationshipGraphNode node)
+        {
+            this.Thing = node.Thing;
+            this.Id = node.Thing.Iid;
+            this.Level = node.Level;
+            this.Name = node.Thing.UserFriendlyName;
+            this.ShortName = node.Thing.UserFriendlyShortName;
+            this.ClassKindName = node.Thing.ClassKind.ToString();
+
+            var definition = (node.Thing as DefinedThing)?.Definition.FirstOrDefault()?.Content;
+            this.ToolTip = definition == null ? this.Name : $"{this.Name}\n{definition}";
+        }
+
+        /// <summary>
+        /// Gets the identifier that the diagram connectors reference, the <see cref="Thing.Iid"/> of the represented
+        /// <see cref="Thing"/>
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the represented <see cref="Thing"/>
+        /// </summary>
+        public Thing Thing { get; }
+
+        /// <summary>
+        /// Gets the level at which the <see cref="Thing"/> was reached: zero for a root, positive downward, negative
+        /// upward
+        /// </summary>
+        public int Level { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="Thing"/> is one of the roots of the traversal
+        /// </summary>
+        public bool IsRoot => this.Level == 0;
+
+        /// <summary>
+        /// Gets the name of the <see cref="Thing"/>
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the short name of the <see cref="Thing"/>
+        /// </summary>
+        public string ShortName { get; }
+
+        /// <summary>
+        /// Gets the name of the <see cref="ClassKind"/> of the <see cref="Thing"/>
+        /// </summary>
+        public string ClassKindName { get; }
+
+        /// <summary>
+        /// Gets the tool tip of the node: the name of the <see cref="Thing"/> followed by the content of its first
+        /// <see cref="Definition"/> when it has one
+        /// </summary>
+        public string ToolTip { get; }
+    }
+}

--- a/CDP4DiagramEditor/Views/RelationshipTraceability.xaml
+++ b/CDP4DiagramEditor/Views/RelationshipTraceability.xaml
@@ -1,0 +1,315 @@
+﻿<UserControl x:Class="CDP4DiagramEditor.Views.RelationshipTraceability"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:dxdiag="http://schemas.devexpress.com/winfx/2008/xaml/diagram"
+             xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
+             xmlns:dxn="http://schemas.devexpress.com/winfx/2008/xaml/navbar"
+             xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+             xmlns:dragDrop="clr-namespace:CDP4Composition.DragDrop;assembly=CDP4Composition"
+             xmlns:behaviors="clr-namespace:CDP4DiagramEditor.Behaviors"
+             xmlns:helpers="clr-namespace:CDP4DiagramEditor.Helpers"
+             xmlns:viewModels="clr-namespace:CDP4DiagramEditor.ViewModels"
+             xmlns:views="clr-namespace:CDP4DiagramEditor.Views"
+             d:DesignHeight="600"
+             d:DesignWidth="900"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <helpers:TraceabilityCategoryListConverter x:Key="CategoryListConverter" />
+        <helpers:TraceabilityClassKindListConverter x:Key="ClassKindListConverter" />
+        <helpers:TraceabilityIntegerConverter x:Key="IntegerConverter" />
+        <helpers:TraceabilityLevelToBrushConverter x:Key="LevelToBrushConverter" />
+
+        <!-- a list that stays out of sight until it has something to show -->
+        <Style x:Key="AutoHideListBox" TargetType="ListBox">
+            <Setter Property="MaxHeight" Value="120" />
+            <Setter Property="Margin" Value="0,3,0,0" />
+            <Style.Triggers>
+                <Trigger Property="HasItems" Value="False">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <dxn:NavBarControl Grid.Column="1" MaxWidth="350" FlowDirection="RightToLeft">
+            <dxn:NavBarControl.View>
+                <dxn:NavigationPaneView IsExpanded="True" AnimateGroupExpansion="False" />
+            </dxn:NavBarControl.View>
+            <dxn:NavBarControl.Groups>
+                <dxn:NavBarGroup DisplaySource="Content" Header="Configuration">
+                    <dxn:NavBarGroup.Content>
+        <dxlc:LayoutControl Orientation="Vertical" FlowDirection="LeftToRight">
+            <dxlc:LayoutGroup Orientation="Vertical">
+                <dxlc:LayoutGroup View="GroupBox" GroupBoxDisplayMode="Light" Header="Presets"
+                                  Orientation="Vertical" IsCollapsible="False" HorizontalAlignment="Stretch">
+                    <dxlc:LayoutItem>
+                    <StackPanel>
+                        <dxe:ComboBoxEdit ItemsSource="{Binding SavedConfigurations}"
+                                          SelectedItem="{Binding SelectedConfiguration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                          DisplayMember="Name"
+                                          AllowNullInput="True"
+                                          NullText="Select a preset..." />
+                        <dxe:TextEdit Margin="0,3,0,0"
+                                      EditValue="{Binding ConfigurationName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      NullText="Preset name" />
+                        <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                            <Button Content="Save" MinWidth="60" Command="{Binding SaveConfigurationCommand}" />
+                            <Button Content="Delete" MinWidth="60" Margin="5,0,0,0" Command="{Binding DeleteConfigurationCommand}" />
+                        </StackPanel>
+                    </StackPanel>
+                    </dxlc:LayoutItem>
+                </dxlc:LayoutGroup>
+
+                <dxlc:LayoutGroup View="GroupBox" GroupBoxDisplayMode="Light" Header="Roots"
+                                  Orientation="Vertical" IsCollapsible="False" HorizontalAlignment="Stretch">
+                    <dxlc:LayoutItem>
+                    <StackPanel>
+                        <TextBlock Text="Drag things from a browser onto the diagram to add roots."
+                                   TextWrapping="Wrap"
+                                   FontStyle="Italic"
+                                   Margin="0,0,0,3" />
+                        <ListBox Style="{StaticResource AutoHideListBox}"
+                                 ItemsSource="{Binding RootThings}"
+                                 SelectedItem="{Binding SelectedRootThing, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding UserFriendlyShortName}" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                        <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                            <Button Content="Remove" MinWidth="60" Command="{Binding RemoveRootThingCommand}" />
+                            <Button Content="Clear" MinWidth="60" Margin="5,0,0,0" Command="{Binding ClearRootThingsCommand}" />
+                        </StackPanel>
+                        <TextBlock Text="And/or all things of:" Margin="0,5,0,3" />
+                        <dxe:ComboBoxEdit ItemsSource="{Binding PossibleClassKinds}"
+                                          EditValue="{Binding SelectedRootClassKinds, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ClassKindListConverter}}"
+                                          AllowNullInput="True"
+                                          NullText="Class kinds...">
+                            <dxe:ComboBoxEdit.StyleSettings>
+                                <dxe:CheckedComboBoxStyleSettings />
+                            </dxe:ComboBoxEdit.StyleSettings>
+                        </dxe:ComboBoxEdit>
+                        <dxe:ComboBoxEdit Margin="0,3,0,0"
+                                          ItemsSource="{Binding PossibleCategories}"
+                                          EditValue="{Binding SelectedRootCategories, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CategoryListConverter}}"
+                                          DisplayMember="Name"
+                                          AllowNullInput="True"
+                                          NullText="Filtered by categories...">
+                            <dxe:ComboBoxEdit.StyleSettings>
+                                <dxe:CheckedComboBoxStyleSettings />
+                            </dxe:ComboBoxEdit.StyleSettings>
+                        </dxe:ComboBoxEdit>
+                    </StackPanel>
+                    </dxlc:LayoutItem>
+                </dxlc:LayoutGroup>
+
+                <dxlc:LayoutGroup View="GroupBox" GroupBoxDisplayMode="Light" Header="Depth"
+                                  Orientation="Vertical" IsCollapsible="False" HorizontalAlignment="Stretch">
+                    <dxlc:LayoutItem>
+                    <StackPanel>
+                        <TextBlock Text="Levels down (source to target):" />
+                        <dxe:SpinEdit Value="{Binding DepthDown, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IntegerConverter}}" MinValue="0" MaxValue="20" IsFloatValue="False" />
+                        <TextBlock Text="Levels up (target to source):" Margin="0,3,0,0" />
+                        <dxe:SpinEdit Value="{Binding DepthUp, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IntegerConverter}}" MinValue="0" MaxValue="20" IsFloatValue="False" />
+                        <TextBlock Text="Maximum nodes:" Margin="0,3,0,0" />
+                        <dxe:SpinEdit Value="{Binding MaxNodes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IntegerConverter}}" MinValue="10" MaxValue="5000" IsFloatValue="False" />
+                    </StackPanel>
+                    </dxlc:LayoutItem>
+                </dxlc:LayoutGroup>
+
+                <dxlc:LayoutGroup View="GroupBox" GroupBoxDisplayMode="Light" Header="Relationship filter"
+                                  Orientation="Vertical" IsCollapsible="False" HorizontalAlignment="Stretch">
+                    <dxlc:LayoutItem>
+                    <StackPanel>
+                        <TextBlock Text="Follow only relationships of category:" TextWrapping="Wrap" />
+                        <dxe:ComboBoxEdit ItemsSource="{Binding PossibleRelationshipCategories}"
+                                          EditValue="{Binding SelectedDefaultLevelCategories, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CategoryListConverter}}"
+                                          DisplayMember="Name"
+                                          AllowNullInput="True"
+                                          NullText="All relationships">
+                            <dxe:ComboBoxEdit.StyleSettings>
+                                <dxe:CheckedComboBoxStyleSettings />
+                            </dxe:ComboBoxEdit.StyleSettings>
+                        </dxe:ComboBoxEdit>
+                        <TextBlock Text="Arrow direction:" Margin="0,5,0,0"
+                                   ToolTip="How relationship arrows are followed. Use this when your hierarchy's arrows point the other way, or Both when they change direction along the chain." />
+                        <dxe:ComboBoxEdit ItemsSource="{Binding PossibleDirections}"
+                                          SelectedItem="{Binding SelectedDefaultDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                          DisplayMember="Label"
+                                          IsTextEditable="False" />
+                        <TextBlock Text="Per-level overrides:" Margin="0,5,0,3"
+                                   ToolTip="At the given level (1 = first hop from the roots) only relationships of the chosen categories are followed, instead of the default filter above. E.g. level 3 → 'Satisfies' follows only satisfies links at the third hop." />
+                        <ListBox Style="{StaticResource AutoHideListBox}"
+                                 MaxHeight="150"
+                                 HorizontalContentAlignment="Stretch"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                 ItemsSource="{Binding LevelFilterRows}"
+                                 SelectedItem="{Binding SelectedLevelFilterRow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type viewModels:TraceabilityLevelFilterRowViewModel}">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="60" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <dxe:SpinEdit Grid.Row="0" Grid.Column="0"
+                                                      Value="{Binding Level, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IntegerConverter}}"
+                                                      MinValue="1" MaxValue="20" IsFloatValue="False" />
+                                        <dxe:ComboBoxEdit Grid.Row="0" Grid.Column="1"
+                                                          Margin="3,0,0,0"
+                                                          ItemsSource="{Binding PossibleCategories}"
+                                                          EditValue="{Binding SelectedCategories, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CategoryListConverter}}"
+                                                          DisplayMember="Name"
+                                                          AllowNullInput="True"
+                                                          NullText="Categories...">
+                                            <dxe:ComboBoxEdit.StyleSettings>
+                                                <dxe:CheckedComboBoxStyleSettings />
+                                            </dxe:ComboBoxEdit.StyleSettings>
+                                        </dxe:ComboBoxEdit>
+                                        <dxe:ComboBoxEdit Grid.Row="1" Grid.Column="1"
+                                                          Margin="3,3,0,0"
+                                                          ItemsSource="{x:Static viewModels:TraceabilityDirectionOption.All}"
+                                                          SelectedItem="{Binding SelectedDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                          DisplayMember="Label"
+                                                          IsTextEditable="False" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                        <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                            <Button Content="Add" MinWidth="60" Command="{Binding AddLevelFilterRowCommand}" />
+                            <Button Content="Remove" MinWidth="60" Margin="5,0,0,0" Command="{Binding RemoveLevelFilterRowCommand}" />
+                        </StackPanel>
+                    </StackPanel>
+                    </dxlc:LayoutItem>
+                </dxlc:LayoutGroup>
+
+                <dxlc:LayoutGroup View="GroupBox" GroupBoxDisplayMode="Light" Header="Diagram"
+                                  Orientation="Vertical" IsCollapsible="False" HorizontalAlignment="Stretch">
+                    <dxlc:LayoutItem>
+                    <StackPanel>
+                        <TextBlock Text="Orientation:" />
+                        <dxe:ComboBoxEdit ItemsSource="{Binding PossibleLayoutDirections}"
+                                          EditValue="{Binding LayoutDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                          DisplayMember="Label"
+                                          ValueMember="Direction"
+                                          IsTextEditable="False" />
+                        <TextBlock Text="Export as:" Margin="0,5,0,0" />
+                        <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                            <Button Content="PNG" MinWidth="50" Command="{Binding ExportCommand}" CommandParameter="PNG" />
+                            <Button Content="JPEG" MinWidth="50" Margin="5,0,0,0" Command="{Binding ExportCommand}" CommandParameter="JPEG" />
+                            <Button Content="SVG" MinWidth="50" Margin="5,0,0,0" Command="{Binding ExportCommand}" CommandParameter="SVG" />
+                        </StackPanel>
+                    </StackPanel>
+                    </dxlc:LayoutItem>
+                </dxlc:LayoutGroup>
+
+                <dxlc:LayoutGroup View="GroupBox" GroupBoxDisplayMode="Light" Header="Excluded from diagram"
+                                  Orientation="Vertical" IsCollapsible="False" HorizontalAlignment="Stretch">
+                    <dxlc:LayoutItem>
+                    <StackPanel>
+                        <TextBlock Text="Right-click a node to exclude it together with everything only reachable through it."
+                                   TextWrapping="Wrap" FontStyle="Italic" Margin="0,0,0,3" />
+                        <ListBox Style="{StaticResource AutoHideListBox}"
+                                 ItemsSource="{Binding ExcludedThings}"
+                                 SelectedItem="{Binding SelectedExcludedThing, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding UserFriendlyShortName}" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                        <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                            <Button Content="Restore" MinWidth="60" Command="{Binding RestoreExcludedThingCommand}" />
+                            <Button Content="Restore all" MinWidth="70" Margin="5,0,0,0" Command="{Binding ResetExclusionsCommand}" />
+                        </StackPanel>
+                    </StackPanel>
+                    </dxlc:LayoutItem>
+                </dxlc:LayoutGroup>
+
+                <dxlc:LayoutItem>
+                    <Button Content="Refresh" Command="{Binding RefreshCommand}" />
+                </dxlc:LayoutItem>
+            </dxlc:LayoutGroup>
+        </dxlc:LayoutControl>
+                    </dxn:NavBarGroup.Content>
+                </dxn:NavBarGroup>
+            </dxn:NavBarControl.Groups>
+        </dxn:NavBarControl>
+
+        <Grid Grid.Column="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0"
+                    Background="#FFF3CD"
+                    BorderBrush="#FFE082"
+                    BorderThickness="1"
+                    Padding="5"
+                    Visibility="{Binding IsMaxNodeCountReached, Converter={dxmvvm:BooleanToVisibilityConverter}}">
+                <TextBlock TextWrapping="Wrap"
+                           Text="The maximum number of nodes was reached; the diagram is incomplete. Raise the maximum, lower the depth or add filters." />
+            </Border>
+
+            <TextBlock Grid.Row="1" Margin="5,2" Text="{Binding StatusMessage}" />
+
+            <views:TraceabilityDiagramControl Grid.Row="2"
+                                              SelectionMode="Single"
+                                              IsManipulationEnabled="False"
+                                              AllowRotateItems="False"
+                                              AllowResizeItems="False"
+                                              AllowApplyAutomaticLayout="True"
+                                              ShowPageBreaks="False">
+                <i:Interaction.Behaviors>
+                    <dragDrop:FrameworkElementDropBehavior />
+                </i:Interaction.Behaviors>
+                <dxmvvm:Interaction.Behaviors>
+                    <behaviors:TraceabilityDiagramBehavior />
+                    <dxmvvm:EventToCommand EventName="SelectionChanged"
+                                           Command="{Binding DiagramSelectionChangedCommand}"
+                                           PassEventArgsToCommand="True" />
+                    <dxdiag:DiagramDataBindingBehavior ItemsSource="{Binding Nodes}"
+                                                       ConnectorsSource="{Binding Edges}"
+                                                       KeyMember="Id"
+                                                       ConnectorFromMember="FromId"
+                                                       ConnectorToMember="ToId">
+                        <dxdiag:DiagramDataBindingBehavior.ItemTemplate>
+                            <DataTemplate DataType="{x:Type viewModels:TraceabilityNodeViewModel}">
+                                <Border Background="{Binding Level, Converter={StaticResource LevelToBrushConverter}}"
+                                        BorderBrush="DimGray"
+                                        BorderThickness="1"
+                                        CornerRadius="3"
+                                        Padding="6,4"
+                                        ToolTip="{Binding ToolTip}">
+                                    <StackPanel Orientation="Vertical">
+                                        <TextBlock Text="{Binding ClassKindName}" FontSize="9" Foreground="DimGray" TextAlignment="Center" />
+                                        <TextBlock Text="{Binding ShortName}" FontWeight="Bold" TextAlignment="Center" />
+                                        <TextBlock Text="{Binding Name}" FontSize="10" TextAlignment="Center" TextWrapping="Wrap" MaxWidth="160" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </dxdiag:DiagramDataBindingBehavior.ItemTemplate>
+                    </dxdiag:DiagramDataBindingBehavior>
+                </dxmvvm:Interaction.Behaviors>
+            </views:TraceabilityDiagramControl>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/CDP4DiagramEditor/Views/RelationshipTraceability.xaml.cs
+++ b/CDP4DiagramEditor/Views/RelationshipTraceability.xaml.cs
@@ -1,0 +1,63 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipTraceability.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Views
+{
+    using System.ComponentModel.Composition;
+    using System.Windows.Controls;
+
+    using CDP4Composition;
+
+    /// <summary>
+    /// Interaction logic for RelationshipTraceability
+    /// </summary>
+    [Export(typeof(IPanelView))]
+    public partial class RelationshipTraceability : UserControl, IPanelView
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipTraceability"/> class.
+        /// </summary>
+        public RelationshipTraceability()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipTraceability"/> class.
+        /// </summary>
+        /// <param name="initializeComponent">
+        /// a value indicating whether the contained Components shall be loaded
+        /// </param>
+        /// <remarks>
+        /// This constructor is called by the navigation service
+        /// </remarks>
+        public RelationshipTraceability(bool initializeComponent)
+        {
+            if (initializeComponent)
+            {
+                this.InitializeComponent();
+            }
+        }
+    }
+}

--- a/CDP4DiagramEditor/Views/RelationshipTraceabilityRibbon.xaml
+++ b/CDP4DiagramEditor/Views/RelationshipTraceabilityRibbon.xaml
@@ -1,0 +1,43 @@
+﻿<ribbon:ExtendedRibbonPageGroup x:Class="CDP4DiagramEditor.Views.RelationshipTraceabilityRibbon"
+                                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                                xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                                xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                                xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                                xmlns:ribbon="clr-namespace:CDP4Composition.Ribbon;assembly=CDP4Composition"
+                                xmlns:cdp4Composition="clr-namespace:CDP4Composition;assembly=CDP4Composition"
+                                mc:Ignorable="d"
+                                ContainerRegionName="{x:Static cdp4Composition:RegionNames.ModelRibbonPageRegion}"
+                                MergeOrder="8010"
+                                Caption="Graphical">
+    <dxr:RibbonPageGroup.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/RibbonMenuItemTemplate.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </dxr:RibbonPageGroup.Resources>
+
+    <dxb:BarSplitButtonItem Name="OpenRelationshipTraceabilityBarButtonItem"
+                            ActAsDropDown="True"
+                            Content="Traceability"
+                            RibbonStyle="Large"
+                            IsEnabled="{Binding HasModels, UpdateSourceTrigger=PropertyChanged}"
+                            LargeGlyph="{dx:DXImage Image=TreeView_32x32.png}"
+                            Hint="Open the relationship traceability diagram">
+        <dxb:BarSplitButtonItem.PopupControl>
+            <dxr:GalleryDropDownPopupMenu>
+                <dxr:GalleryDropDownPopupMenu.Gallery>
+                    <dxb:Gallery ColCount="1"
+                                 GroupTemplate="{StaticResource groupTemplate}"
+                                 GroupsSource="{Binding OpenModels}"
+                                 IsGroupCaptionVisible="True"
+                                 ItemCheckMode="Multiple" />
+                </dxr:GalleryDropDownPopupMenu.Gallery>
+            </dxr:GalleryDropDownPopupMenu>
+        </dxb:BarSplitButtonItem.PopupControl>
+    </dxb:BarSplitButtonItem>
+
+</ribbon:ExtendedRibbonPageGroup>

--- a/CDP4DiagramEditor/Views/RelationshipTraceabilityRibbon.xaml.cs
+++ b/CDP4DiagramEditor/Views/RelationshipTraceabilityRibbon.xaml.cs
@@ -1,0 +1,55 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipTraceabilityRibbon.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Views
+{
+    using System.ComponentModel.Composition;
+
+    using CDP4Composition.Mvvm;
+    using CDP4Composition.Ribbon;
+
+    using CDP4Dal;
+
+    using CDP4DiagramEditor.ViewModels;
+
+    using CommonServiceLocator;
+
+    /// <summary>
+    /// Interaction logic for RelationshipTraceabilityRibbon.xaml
+    /// </summary>
+    [Export(typeof(ExtendedRibbonPageGroup))]
+    public partial class RelationshipTraceabilityRibbon : ExtendedRibbonPageGroup, IView
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipTraceabilityRibbon" /> class.
+        /// </summary>
+        public RelationshipTraceabilityRibbon()
+        {
+            this.InitializeComponent();
+            var messageBus = ServiceLocator.Current.GetInstance<ICDPMessageBus>();
+            this.DataContext = new RelationshipTraceabilityRibbonViewModel(messageBus);
+        }
+    }
+}

--- a/CDP4DiagramEditor/Views/TraceabilityDiagramControl.cs
+++ b/CDP4DiagramEditor/Views/TraceabilityDiagramControl.cs
@@ -1,0 +1,80 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TraceabilityDiagramControl.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4DiagramEditor.Views
+{
+    using System.Collections.Generic;
+
+    using CDP4DiagramEditor.ViewModels;
+
+    using DevExpress.Xpf.Bars;
+    using DevExpress.Xpf.Diagram;
+
+    /// <summary>
+    /// The <see cref="DiagramControl"/> of the relationship traceability panel: it replaces the built-in context menu
+    /// with the traceability actions
+    /// </summary>
+    public class TraceabilityDiagramControl : DiagramControl
+    {
+        /// <summary>
+        /// Builds the context menu of the diagram
+        /// </summary>
+        /// <returns>The context menu items</returns>
+        protected override IEnumerable<IBarManagerControllerAction> CreateContextMenu()
+        {
+            if (!(this.DataContext is RelationshipTraceabilityViewModel viewModel))
+            {
+                yield break;
+            }
+
+            yield return new BarButtonItem
+            {
+                Content = "Exclude from diagram",
+                ToolTip = "Removes the selected node, together with everything only reachable through it",
+                Command = viewModel.ExcludeSelectedNodeCommand
+            };
+
+            yield return new BarButtonItem
+            {
+                Content = "Restore all excluded",
+                Command = viewModel.ResetExclusionsCommand
+            };
+
+            var exportSubItem = new BarSubItem { Content = "Export as" };
+
+            foreach (var format in new[] { "PNG", "JPEG", "SVG" })
+            {
+                exportSubItem.Items.Add(new BarButtonItem
+                {
+                    Content = format,
+                    Command = viewModel.ExportCommand,
+                    CommandParameter = format
+                });
+            }
+
+            yield return exportSubItem;
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #1466 Configurable relationship traceability diagram

Adds a new Relationship Traceability panel to the Diagram Editor plugin. It renders a read-only diagram of everything reachable from a set of root things by walking BinaryRelationships and MultiRelationships, without writing anything to the model.

* Roots by drag and drop from any browser and/or by class kind and category selection, mirroring the Relationship Matrix configuration.
* Separate depth limits for downstream and upstream traversal, with a maximum node guard and a warning when it trips.
* Relationship filtering by category, with a configurable arrow direction (along, against, both) as default and per level, so hierarchies whose relationship arrows change direction along the chain can be shown in one diagram.
* Sugiyama auto layout in four orientations; connectors run in traversal level order while arrow heads keep the true relationship direction; undirected multi relationships are drawn without arrow heads.
* Right click to exclude a node together with everything only reachable through it, with a restore list in the panel.
* Selecting a node publishes it to the property grid.
* Named presets saved through the plugin settings service.
* Export to PNG, JPEG and SVG (SVG is generated from the laid out items because the built-in export skips templated node content).

The traversal lives in a UI-free RelationshipGraphBuilder with pre-indexed relationship lookups. The configuration pane uses the same NavBar/LayoutControl arrangement as the Relationship Matrix.

<img width="1888" height="845" alt="image" src="https://github.com/user-attachments/assets/cc18c713-5325-4757-b373-36eb2d71b88c" />


