### PR TITLE
Fix #1457 Operation failed from a compound parameter type

### DIFF
--- a/CDP4Composition/Extensions/CompoundParameterTypeExtensions.cs
+++ b/CDP4Composition/Extensions/CompoundParameterTypeExtensions.cs
@@ -1,0 +1,64 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CompoundParameterTypeExtensions.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Extensions
+{
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// The purpose of these <see cref="CompoundParameterTypeExtensions"/> is to add functionality to <see cref="CompoundParameterType"/> instances
+    /// </summary>
+    public static class CompoundParameterTypeExtensions
+    {
+        /// <summary>
+        /// Queries the <see cref="ParameterTypeComponent"/> at the specified index
+        /// </summary>
+        /// <param name="compoundParameterType">
+        /// The <see cref="CompoundParameterType"/> that contains the <see cref="ParameterTypeComponent"/>
+        /// </param>
+        /// <param name="componentIndex">
+        /// The index of the <see cref="ParameterTypeComponent"/>
+        /// </param>
+        /// <returns>
+        /// The <see cref="ParameterTypeComponent"/> at <paramref name="componentIndex"/>, or null when the
+        /// <see cref="CompoundParameterType"/> does not contain a component at that index
+        /// </returns>
+        /// <remarks>
+        /// A <see cref="CompoundParameterType"/> that could not be resolved from the cache - for instance because the
+        /// <see cref="ReferenceDataLibrary"/> that contains it is not (yet) available on the client - has no components
+        /// at all, while the rows that represent its values still address them by index. Indexing the component list
+        /// directly then terminates the operation with an exception, see issue #1457.
+        /// </remarks>
+        public static ParameterTypeComponent QueryComponent(this CompoundParameterType compoundParameterType, int componentIndex)
+        {
+            if (componentIndex < 0 || componentIndex >= compoundParameterType.Component.Count)
+            {
+                return null;
+            }
+
+            return compoundParameterType.Component[componentIndex];
+        }
+    }
+}

--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -34,6 +34,8 @@ namespace CDP4CrossViewEditor.Assemblers
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
+    using CDP4Composition.Extensions;
+
     using CDP4CrossViewEditor.Generator;
     using CDP4CrossViewEditor.RowModels.CrossviewSheet;
 
@@ -355,7 +357,13 @@ namespace CDP4CrossViewEditor.Assemblers
                     {
                         for (var i = 0; i < compoundParameterType.NumberOfValues; ++i)
                         {
-                            var component = compoundParameterType.Component[i];
+                            var component = compoundParameterType.QueryComponent(i);
+
+                            if (component == null || parameterValueSetBase.ActualValue.Count <= i)
+                            {
+                                continue;
+                            }
+
                             var value = parameterValueSetBase.ActualValue[i];
 
                             var index = this.GetContentColumnIndex(parameterValueSetBase, component);

--- a/CDP4ParameterSheetGenerator/Generator/ParameterSheetUtilities.cs
+++ b/CDP4ParameterSheetGenerator/Generator/ParameterSheetUtilities.cs
@@ -11,6 +11,7 @@ namespace CDP4ParameterSheetGenerator.Generator
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Validation;
+    using CDP4Composition.Extensions;
     using CDP4OfficeInfrastructure.Excel;
     using CDP4ParameterSheetGenerator.ParameterSheet;
     using NetOffice.ExcelApi;
@@ -395,9 +396,9 @@ namespace CDP4ParameterSheetGenerator.Generator
             }
 
             var compoundParameterType = parameter.ParameterType as CompoundParameterType;
-            if (compoundParameterType != null)
+            var component = compoundParameterType?.QueryComponent(componentIndex);
+            if (component != null)
             {
-                var component = compoundParameterType.Component[componentIndex];
                 parameterType = component.ParameterType;
                 measurementScale = component.Scale;
                 return;
@@ -437,9 +438,9 @@ namespace CDP4ParameterSheetGenerator.Generator
             }
 
             var compoundParameterType = parameterOverride.ParameterType as CompoundParameterType;
-            if (compoundParameterType != null)
+            var component = compoundParameterType?.QueryComponent(componentIndex);
+            if (component != null)
             {
-                var component = compoundParameterType.Component[componentIndex];
                 parameterType = component.ParameterType;
                 measurementScale = component.Scale;
                 return;
@@ -479,9 +480,9 @@ namespace CDP4ParameterSheetGenerator.Generator
             }
 
             var compoundParameterType = parameterSubscription.ParameterType as CompoundParameterType;
-            if (compoundParameterType != null)
+            var component = compoundParameterType?.QueryComponent(componentIndex);
+            if (component != null)
             {
-                var component = compoundParameterType.Component[componentIndex];
                 parameterType = component.ParameterType;
                 measurementScale = component.Scale;
                 return;

--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionTreeRows/ParameterOptionRowViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionTreeRows/ParameterOptionRowViewModelTestFixture.cs
@@ -149,5 +149,34 @@ namespace CDP4EngineeringModel.Tests.ViewModels.ElementDefinitionTreeRows
             this.messageBus.SendObjectChangeEvent(this.option, EventKind.Updated);
             Assert.That(row.Name, Is.EqualTo(this.option.Name));
         }
+
+        [Test]
+        public void VerifyThatARowOfACompoundParameterTypeWithoutComponentDoesNotThrow()
+        {
+            // a CompoundParameterType without components is what the CDP4-COMET-SDK yields when the ParameterType
+            // of a Parameter cannot be resolved from the cache, see issue #1457
+            var unresolvedParameterType = new CompoundParameterType(Guid.NewGuid(), this.cache, this.uri) { ShortName = "unresolved" };
+
+            this.elementDefinition.ShortName = "ED";
+            this.option.ShortName = "OPT";
+
+            var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ParameterType = unresolvedParameterType,
+                Owner = this.activeDomain,
+                IsOptionDependent = true
+            };
+
+            var valueSet = new ParameterValueSet(Guid.NewGuid(), this.cache, this.uri) { ActualOption = this.option };
+
+            parameter.ValueSet.Add(valueSet);
+            this.elementDefinition.Parameter.Add(parameter);
+
+            var row = new ParameterOptionRowViewModel(parameter, this.option, this.session.Object, null, false);
+
+            Assert.DoesNotThrow(() => row.UpdateModelCode());
+            Assert.DoesNotThrow(() => { var _ = row.IsMultiSelect; });
+            Assert.DoesNotThrow(() => { var _ = row.EnumerationValueDefinition; });
+        }
     }
 }

--- a/EngineeringModel/ViewModels/Dialogs/Rows/ParameterComponentValueRowViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/Rows/ParameterComponentValueRowViewModel.cs
@@ -35,6 +35,7 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Validation;
 
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
 
     using CDP4Dal;
@@ -160,7 +161,7 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
         {
             base.UpdateValues();
             var compoundParameterType = (CompoundParameterType)this.Thing.ParameterType;
-            this.Scale = compoundParameterType.Component[this.ValueIndex].Scale;
+            this.Scale = compoundParameterType.QueryComponent(this.ValueIndex)?.Scale;
             this.ScaleShortName = this.Scale == null ? "-" : this.Scale.ShortName;
         }
 

--- a/EngineeringModel/ViewModels/Dialogs/Rows/ParameterValueBaseRowViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/Rows/ParameterValueBaseRowViewModel.cs
@@ -35,6 +35,7 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Validation;
 
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.ViewModels;
 
@@ -192,7 +193,7 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
                     return false;
                 }
 
-                enumPt = cpt.Component[this.ValueIndex].ParameterType as EnumerationParameterType;
+                enumPt = cpt.QueryComponent(this.ValueIndex)?.ParameterType as EnumerationParameterType;
 
                 if (enumPt == null)
                 {
@@ -238,7 +239,7 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
 
                 if (cpt != null)
                 {
-                    enumPt = cpt.Component[this.ValueIndex].ParameterType as EnumerationParameterType;
+                    enumPt = cpt.QueryComponent(this.ValueIndex)?.ParameterType as EnumerationParameterType;
 
                     if (enumPt != null)
                     {

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterComponentValueRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterComponentValueRowViewModel.cs
@@ -33,6 +33,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
 
+    using CDP4Composition.Extensions;
     using CDP4Composition.MessageBus;
     using CDP4Composition.Mvvm;
 
@@ -183,7 +184,7 @@ namespace CDP4EngineeringModel.ViewModels
                 throw new InvalidOperationException("This row shall only be used for CompoundParameterType.");
             }
 
-            this.Scale = compoundParameterType.Component[this.ValueIndex].Scale;
+            this.Scale = compoundParameterType.QueryComponent(this.ValueIndex)?.Scale;
             this.ScaleShortName = this.Scale == null ? "-" : this.Scale.ShortName;
 
             if (this.Thing is ParameterSubscription)

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterValueBaseRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterValueBaseRowViewModel.cs
@@ -34,6 +34,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
 
+    using CDP4Composition.Extensions;
     using CDP4Composition.MessageBus;
     using CDP4Composition.Mvvm;
     using CDP4Composition.ViewModels;
@@ -206,7 +207,7 @@ namespace CDP4EngineeringModel.ViewModels
                     return false;
                 }
 
-                enumPt = cpt.Component[this.ValueIndex].ParameterType as EnumerationParameterType;
+                enumPt = cpt.QueryComponent(this.ValueIndex)?.ParameterType as EnumerationParameterType;
 
                 if (enumPt == null)
                 {
@@ -243,7 +244,7 @@ namespace CDP4EngineeringModel.ViewModels
 
                 if (cpt != null)
                 {
-                    enumPt = cpt.Component[this.ValueIndex].ParameterType as EnumerationParameterType;
+                    enumPt = cpt.QueryComponent(this.ValueIndex)?.ParameterType as EnumerationParameterType;
 
                     if (enumPt != null)
                     {

--- a/Requirements/ViewModels/Dialogs/RequirementsContainerParameterValueRowViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementsContainerParameterValueRowViewModel.cs
@@ -12,6 +12,7 @@ namespace CDP4Requirements.ViewModels.Dialogs
     using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.ViewModels;
     using CDP4Dal;
@@ -113,7 +114,7 @@ namespace CDP4Requirements.ViewModels.Dialogs
                     return false;
                 }
 
-                enumPt = cpt.Component[this.valueIndex].ParameterType as EnumerationParameterType;
+                enumPt = cpt.QueryComponent(this.valueIndex)?.ParameterType as EnumerationParameterType;
                 if (enumPt == null)
                 {
                     return false;
@@ -154,7 +155,7 @@ namespace CDP4Requirements.ViewModels.Dialogs
                 var cpt = this.Thing.ParameterType as CompoundParameterType;
                 if (cpt != null)
                 {
-                    enumPt = cpt.Component[this.valueIndex].ParameterType as EnumerationParameterType;
+                    enumPt = cpt.QueryComponent(this.valueIndex)?.ParameterType as EnumerationParameterType;
                     if (enumPt != null)
                     {
                         enumValues.AddRange(enumPt.ValueDefinition);
@@ -177,14 +178,15 @@ namespace CDP4Requirements.ViewModels.Dialogs
             }
 
             var cptPt = this.Thing.ParameterType as CompoundParameterType;
-            if (cptPt == null)
+            var cpt = cptPt?.QueryComponent(this.valueIndex);
+
+            if (cpt == null)
             {
                 this.ParameterType = this.Thing.ParameterType;
                 this.Scale = this.Thing.Scale;
             }
             else
             {
-                var cpt = cptPt.Component[this.valueIndex];
                 this.ParameterType = cpt.ParameterType;
                 this.Scale = cpt.Scale;
             }

--- a/Requirements/ViewModels/Dialogs/SimpleParameterValueRowViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/SimpleParameterValueRowViewModel.cs
@@ -12,6 +12,7 @@ namespace CDP4Requirements.ViewModels.Dialogs
     using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.ViewModels;
     using CDP4Dal;
@@ -114,7 +115,7 @@ namespace CDP4Requirements.ViewModels.Dialogs
                     return false;
                 }
 
-                enumPt = cpt.Component[this.valueIndex].ParameterType as EnumerationParameterType;
+                enumPt = cpt.QueryComponent(this.valueIndex)?.ParameterType as EnumerationParameterType;
                 if (enumPt == null)
                 {
                     return false;
@@ -155,7 +156,7 @@ namespace CDP4Requirements.ViewModels.Dialogs
                 var cpt = this.Thing.ParameterType as CompoundParameterType;
                 if (cpt != null)
                 {
-                    enumPt = cpt.Component[this.valueIndex].ParameterType as EnumerationParameterType;
+                    enumPt = cpt.QueryComponent(this.valueIndex)?.ParameterType as EnumerationParameterType;
                     if (enumPt != null)
                     {
                         enumValues.AddRange(enumPt.ValueDefinition);
@@ -178,14 +179,15 @@ namespace CDP4Requirements.ViewModels.Dialogs
             }
 
             var cptPt = this.Thing.ParameterType as CompoundParameterType;
-            if (cptPt == null)
+            var cpt = cptPt?.QueryComponent(this.valueIndex);
+
+            if (cpt == null)
             {
                 this.ParameterType = this.Thing.ParameterType;
                 this.Scale = this.Thing.Scale;
             }
             else
             {
-                var cpt = cptPt.Component[this.valueIndex];
                 this.ParameterType = cpt.ParameterType;
                 this.Scale = cpt.Scale;
             }

--- a/Requirements/ViewModels/RequirementBrowser/Rows/SimpleParameterValueRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/SimpleParameterValueRowViewModel.cs
@@ -35,6 +35,7 @@ namespace CDP4Requirements.ViewModels
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.ViewModels;
 
@@ -122,7 +123,7 @@ namespace CDP4Requirements.ViewModels
                     return false;
                 }
 
-                enumPt = cpt.Component[0].ParameterType as EnumerationParameterType;
+                enumPt = cpt.QueryComponent(0)?.ParameterType as EnumerationParameterType;
 
                 if (enumPt == null)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
## Fix #1457 "Operation Failed" from a CompoundParameterType with no components

### Problem
A `CompoundParameterType` whose `Component` list is empty makes every `Component[index]`
access throw `ArgumentOutOfRangeException: The index 0 does not exist in the OrderedItemList,
the list is empty`, surfacing as an "Operation Failed" dialog.

This happens when a `Parameter`'s `ParameterType` cannot be resolved from the client cache
`SentinelThingProvider` then substitutes an `ArrayParameterType` (a `CompoundParameterType`)
with zero components, so `as CompoundParameterType` succeeds and the index access blows up.
Broken reference data produces the same condition.

The stack reported in #1457 was fixed upstream in
CDP4-COMET-SDK 30.1.3 (STARIONGROUP/COMET-SDK-Community-Edition@8b695c96), which this repo
already references. This PR fixes the remaining occurrences of the same bug class in the IME,
where a component is addressed by an index that is not bounded by the component list.

### Change
Adds `CompoundParameterTypeExtensions.QueryComponent(index)` in `CDP4Composition`, returning
`null` instead of throwing when the component does not exist, and applies it at every
unguarded `Component[...]` site:

- `EngineeringModel`: `ParameterValueBaseRowViewModel` and `ParameterComponentValueRowViewModel`
  (ElementDefinition browser and dialog copies). Option and state rows always pass index 0.
- `Requirements`: `SimpleParameterValueRowViewModel` (browser + dialog) and
  `RequirementsContainerParameterValueRowViewModel`
- `CDP4ParameterSheetGenerator`:  all three `ParameterSheetUtilities.QueryParameterTypeAndScale`
  overloads now fall through to their existing "could not be queried" path
- `CDP4CrossViewEditor`: `CrossviewArrayAssembler` skips columns it cannot resolve

Rows and cells now degrade gracefully instead of terminating the operation.



