### PR TITLE
Fix 1461 Should not be able to create participant from deprecated person

### DIFF
--- a/CDP4SiteDirectory.Tests/Dialogs/ParticipantDialogViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/Dialogs/ParticipantDialogViewModelTestFixture.cs
@@ -196,6 +196,21 @@ namespace CDP4SiteDirectory.Tests.Dialogs
         }
 
         [Test]
+        public void VerifyThatDeprecatedPersonIsNotAPossiblePerson()
+        {
+            var deprecatedPerson = new Person(Guid.NewGuid(), this.cache, this.uri) { IsDeprecated = true };
+            this.sitedir.Person.Add(deprecatedPerson);
+
+            var participant = new Participant(Guid.NewGuid(), this.cache, this.uri);
+
+            var dialog = new ParticipantDialogViewModel(participant, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.clone);
+
+            Assert.That(dialog.PossiblePerson, Does.Not.Contain(deprecatedPerson));
+            Assert.That(dialog.PossiblePerson, Does.Contain(this.person));
+        }
+
+        [Test]
         public void VerifyOkCanExecute()
         {
             var participant = new Participant(Guid.NewGuid(), this.cache, this.uri);

--- a/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
@@ -151,7 +151,7 @@ namespace CDP4SiteDirectory.ViewModels
 
             if (this.dialogKind == ThingDialogKind.Create)
             {
-                foreach (var person in sitedir.Person.OrderBy(x => x.Name).Except(model.Participant.Select(p => p.Person)))
+                foreach (var person in sitedir.Person.Where(x => !x.IsDeprecated).OrderBy(x => x.Name).Except(model.Participant.Select(p => p.Person)))
                 {
                     this.PossiblePerson.Add(person);
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #1461 Now the create participant filters persons on deprecated
ParticipantDialogViewModel.cs:154: added .Where(x => !x.IsDeprecated)
