### PR TITLE
#1487 Fixed the ReqIF Exporter to not have a specobjectType for each requirement.

### DIFF
--- a/Requirements.Tests/Dialogs/ReqIfExportDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/ReqIfExportDialogViewModelTestFixture.cs
@@ -110,13 +110,13 @@ namespace CDP4Requirements.Tests.Controls
             var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(vm);
-                Assert.IsNotNull(vm.Sessions);
-                Assert.IsNotNull(vm.Iterations);
-                Assert.IsNotNull(vm.OkCommand);
-                Assert.IsNotNull(vm.CancelCommand);
-                Assert.IsNotNull(vm.BrowseCommand);
-                Assert.IsFalse(vm.IncludeDeprecated);
+                Assert.That(vm, Is.Not.Null);
+                Assert.That(vm.Sessions, Is.Not.Null);
+                Assert.That(vm.Iterations, Is.Not.Null);
+                Assert.That(vm.OkCommand, Is.Not.Null);
+                Assert.That(vm.CancelCommand, Is.Not.Null);
+                Assert.That(vm.BrowseCommand, Is.Not.Null);
+                Assert.That(vm.IncludeDeprecated, Is.False);
             });
         }
 
@@ -154,14 +154,14 @@ namespace CDP4Requirements.Tests.Controls
 
             var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
 
-            Assert.IsEmpty(vm.RequirementsSpecifications);
+            Assert.That(vm.RequirementsSpecifications, Is.Empty);
 
             vm.SelectedIteration = vm.Iterations.First();
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(2, vm.RequirementsSpecifications.Count);
-                Assert.IsTrue(vm.RequirementsSpecifications.All(x => x.IsSelected));
+                Assert.That(vm.RequirementsSpecifications, Has.Count.EqualTo(2));
+                Assert.That(vm.RequirementsSpecifications.All(x => x.IsSelected), Is.True);
             });
         }
 
@@ -203,7 +203,7 @@ namespace CDP4Requirements.Tests.Controls
 
             vm.SelectedIteration = vm.Iterations.First();
 
-            Assert.IsEmpty(vm.SpecObjectTypesPreview);
+            Assert.That(vm.SpecObjectTypesPreview, Is.Empty);
 
             await vm.PreviewSpecObjectTypesCommand.Execute();
 
@@ -240,7 +240,7 @@ namespace CDP4Requirements.Tests.Controls
             Assert.Multiple(() =>
             {
                 Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Contain(deprecatedSpec));
-                Assert.IsTrue(vm.RequirementsSpecifications.All(x => x.IsSelected));
+                Assert.That(vm.RequirementsSpecifications.All(x => x.IsSelected), Is.True);
             });
         }
 
@@ -263,7 +263,7 @@ namespace CDP4Requirements.Tests.Controls
 
             Assert.Multiple(() =>
             {
-                Assert.IsEmpty(vm.SpecObjectTypesPreview);
+                Assert.That(vm.SpecObjectTypesPreview, Is.Empty);
                 Assert.That(vm.ErrorMessage, Is.EqualTo("Select at least one requirements specification to preview."));
             });
         }
@@ -286,14 +286,14 @@ namespace CDP4Requirements.Tests.Controls
                 Assert.That(vm.SelectedIteration.IterationNumber, Is.Not.Null.Or.Empty);
                 Assert.That(vm.SelectedIteration.Model, Is.Not.Null.Or.Empty);
                 Assert.That(vm.SelectedIteration.DataSourceUri, Is.Not.Null.Or.Empty);
-                Assert.IsNotNull(vm.SelectedIteration.Iteration);
+                Assert.That(vm.SelectedIteration.Iteration, Is.Not.Null);
             });
 
             Assert.Multiple(() =>
             {
-                Assert.IsFalse(((ICommand)vm.OkCommand).CanExecute(null));
-                Assert.IsTrue(((ICommand)vm.CancelCommand).CanExecute(null));
-                Assert.IsTrue(((ICommand)vm.BrowseCommand).CanExecute(null));
+                Assert.That(((ICommand)vm.OkCommand).CanExecute(null), Is.False);
+                Assert.That(((ICommand)vm.CancelCommand).CanExecute(null), Is.True);
+                Assert.That(((ICommand)vm.BrowseCommand).CanExecute(null), Is.True);
             });
 
             await vm.BrowseCommand.Execute();
@@ -301,11 +301,11 @@ namespace CDP4Requirements.Tests.Controls
             {
                 Assert.That(vm.Path, Is.Not.Null.Or.Empty);
 
-                Assert.IsTrue(((ICommand)vm.OkCommand).CanExecute(null));
+                Assert.That(((ICommand)vm.OkCommand).CanExecute(null), Is.True);
             });
 
             await vm.ExecuteOk();
-            Assert.IsNotNull(vm.DialogResult);
+            Assert.That(vm.DialogResult, Is.Not.Null);
         }
     }
 }

--- a/Requirements.Tests/Dialogs/ReqIfExportDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/ReqIfExportDialogViewModelTestFixture.cs
@@ -108,13 +108,16 @@ namespace CDP4Requirements.Tests.Controls
         public void VerifyThatConstructorWorks()
         {
             var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
-            Assert.IsNotNull(vm);
-            Assert.IsNotNull(vm.Sessions);
-            Assert.IsNotNull(vm.Iterations);
-            Assert.IsNotNull(vm.OkCommand);
-            Assert.IsNotNull(vm.CancelCommand);
-            Assert.IsNotNull(vm.BrowseCommand);
-            Assert.IsFalse(vm.IncludeDeprecated);
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(vm);
+                Assert.IsNotNull(vm.Sessions);
+                Assert.IsNotNull(vm.Iterations);
+                Assert.IsNotNull(vm.OkCommand);
+                Assert.IsNotNull(vm.CancelCommand);
+                Assert.IsNotNull(vm.BrowseCommand);
+                Assert.IsFalse(vm.IncludeDeprecated);
+            });
         }
 
         [Test]
@@ -155,8 +158,11 @@ namespace CDP4Requirements.Tests.Controls
 
             vm.SelectedIteration = vm.Iterations.First();
 
-            Assert.AreEqual(2, vm.RequirementsSpecifications.Count);
-            Assert.IsTrue(vm.RequirementsSpecifications.All(x => x.IsSelected));
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(2, vm.RequirementsSpecifications.Count);
+                Assert.IsTrue(vm.RequirementsSpecifications.All(x => x.IsSelected));
+            });
         }
 
         [Test]
@@ -202,8 +208,11 @@ namespace CDP4Requirements.Tests.Controls
             await vm.PreviewSpecObjectTypesCommand.Execute();
 
             var requirementType = vm.SpecObjectTypesPreview.Single(x => x.Name == "Requirement");
-            Assert.That(requirementType.NumberOfObjects, Is.EqualTo(1));
-            Assert.That(requirementType.DistinguishingAttributes, Is.EqualTo("(no extra parameters)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(requirementType.NumberOfObjects, Is.EqualTo(1));
+                Assert.That(requirementType.DistinguishingAttributes, Is.EqualTo("(no extra parameters)"));
+            });
         }
 
         [Test]
@@ -219,14 +228,20 @@ namespace CDP4Requirements.Tests.Controls
             vm.SelectedIteration = vm.Iterations.First();
 
             // the deprecated specification is hidden by default (Include Deprecated is off)
-            Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Contain(normalSpec));
-            Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Not.Contain(deprecatedSpec));
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Contain(normalSpec));
+                Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Not.Contain(deprecatedSpec));
+            });
 
             // turning on Include Deprecated reveals it, selected by default
             vm.IncludeDeprecated = true;
 
-            Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Contain(deprecatedSpec));
-            Assert.IsTrue(vm.RequirementsSpecifications.All(x => x.IsSelected));
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Contain(deprecatedSpec));
+                Assert.IsTrue(vm.RequirementsSpecifications.All(x => x.IsSelected));
+            });
         }
 
         [Test]
@@ -246,8 +261,11 @@ namespace CDP4Requirements.Tests.Controls
 
             await vm.PreviewSpecObjectTypesCommand.Execute();
 
-            Assert.IsEmpty(vm.SpecObjectTypesPreview);
-            Assert.That(vm.ErrorMessage, Is.EqualTo("Select at least one requirements specification to preview."));
+            Assert.Multiple(() =>
+            {
+                Assert.IsEmpty(vm.SpecObjectTypesPreview);
+                Assert.That(vm.ErrorMessage, Is.EqualTo("Select at least one requirements specification to preview."));
+            });
         }
 
         [Test]
@@ -263,19 +281,28 @@ namespace CDP4Requirements.Tests.Controls
                 .Returns("test");
 
             vm.SelectedIteration = vm.Iterations.First();
-            Assert.That(vm.SelectedIteration.IterationNumber, Is.Not.Null.Or.Empty);
-            Assert.That(vm.SelectedIteration.Model, Is.Not.Null.Or.Empty);
-            Assert.That(vm.SelectedIteration.DataSourceUri, Is.Not.Null.Or.Empty);
-            Assert.IsNotNull(vm.SelectedIteration.Iteration);
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm.SelectedIteration.IterationNumber, Is.Not.Null.Or.Empty);
+                Assert.That(vm.SelectedIteration.Model, Is.Not.Null.Or.Empty);
+                Assert.That(vm.SelectedIteration.DataSourceUri, Is.Not.Null.Or.Empty);
+                Assert.IsNotNull(vm.SelectedIteration.Iteration);
+            });
 
-            Assert.IsFalse(((ICommand)vm.OkCommand).CanExecute(null));
-            Assert.IsTrue(((ICommand)vm.CancelCommand).CanExecute(null));
-            Assert.IsTrue(((ICommand)vm.BrowseCommand).CanExecute(null));
+            Assert.Multiple(() =>
+            {
+                Assert.IsFalse(((ICommand)vm.OkCommand).CanExecute(null));
+                Assert.IsTrue(((ICommand)vm.CancelCommand).CanExecute(null));
+                Assert.IsTrue(((ICommand)vm.BrowseCommand).CanExecute(null));
+            });
 
             await vm.BrowseCommand.Execute();
-            Assert.That(vm.Path, Is.Not.Null.Or.Empty);
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm.Path, Is.Not.Null.Or.Empty);
 
-            Assert.IsTrue(((ICommand)vm.OkCommand).CanExecute(null));
+                Assert.IsTrue(((ICommand)vm.OkCommand).CanExecute(null));
+            });
 
             await vm.ExecuteOk();
             Assert.IsNotNull(vm.DialogResult);

--- a/Requirements.Tests/Dialogs/ReqIfExportDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/ReqIfExportDialogViewModelTestFixture.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReqIfExportDialogViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
 //
@@ -32,6 +32,7 @@ namespace CDP4Requirements.Tests.Controls
     using System.Reactive.Linq;
     using System.Threading.Tasks;
     using System.Windows.Input;
+    using System.Xml.Schema;
 
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
@@ -141,8 +142,120 @@ namespace CDP4Requirements.Tests.Controls
         }
 
         [Test]
+        public void VerifyThatSelectingIterationPopulatesRequirementsSpecificationsSelectedByDefault()
+        {
+            var spec1 = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "spec1", Name = "Specification 1" };
+            var spec2 = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "spec2", Name = "Specification 2" };
+            this.iteration.RequirementsSpecification.Add(spec1);
+            this.iteration.RequirementsSpecification.Add(spec2);
+
+            var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
+
+            Assert.IsEmpty(vm.RequirementsSpecifications);
+
+            vm.SelectedIteration = vm.Iterations.First();
+
+            Assert.AreEqual(2, vm.RequirementsSpecifications.Count);
+            Assert.IsTrue(vm.RequirementsSpecifications.All(x => x.IsSelected));
+        }
+
+        [Test]
+        public async Task VerifyThatExportWithoutSelectedSpecificationIsBlocked()
+        {
+            var spec1 = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "spec1", Name = "Specification 1" };
+            this.iteration.RequirementsSpecification.Add(spec1);
+
+            this.fileDialogService.Setup(
+                    x => x.GetSaveFileDialog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), 1))
+                .Returns("test");
+
+            var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
+
+            vm.SelectedIteration = vm.Iterations.First();
+            await vm.BrowseCommand.Execute();
+
+            foreach (var row in vm.RequirementsSpecifications)
+            {
+                row.IsSelected = false;
+            }
+
+            await vm.ExecuteOk();
+
+            Assert.That(vm.ErrorMessage, Is.EqualTo("Select at least one requirements specification to export."));
+            this.serializer.Verify(x => x.Serialize(It.IsAny<ReqIF>(), It.IsAny<string>(), It.IsAny<ValidationEventHandler>()), Times.Never);
+        }
+
+        [Test]
+        public async Task VerifyThatPreviewSpecObjectTypesListsTheExportedTypes()
+        {
+            var spec = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "spec", Name = "Specification" };
+            var requirement = new Requirement(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "req1", Name = "Requirement 1" };
+            spec.Requirement.Add(requirement);
+            this.iteration.RequirementsSpecification.Add(spec);
+
+            var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
+
+            vm.SelectedIteration = vm.Iterations.First();
+
+            Assert.IsEmpty(vm.SpecObjectTypesPreview);
+
+            await vm.PreviewSpecObjectTypesCommand.Execute();
+
+            var requirementType = vm.SpecObjectTypesPreview.Single(x => x.Name == "Requirement");
+            Assert.That(requirementType.NumberOfObjects, Is.EqualTo(1));
+            Assert.That(requirementType.DistinguishingAttributes, Is.EqualTo("(no extra parameters)"));
+        }
+
+        [Test]
+        public void VerifyThatDeprecatedSpecificationsAreHiddenUnlessIncludeDeprecatedIsChecked()
+        {
+            var normalSpec = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "spec", Name = "Specification" };
+            var deprecatedSpec = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "dep", Name = "Deprecated", IsDeprecated = true };
+            this.iteration.RequirementsSpecification.Add(normalSpec);
+            this.iteration.RequirementsSpecification.Add(deprecatedSpec);
+
+            var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
+
+            vm.SelectedIteration = vm.Iterations.First();
+
+            // the deprecated specification is hidden by default (Include Deprecated is off)
+            Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Contain(normalSpec));
+            Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Not.Contain(deprecatedSpec));
+
+            // turning on Include Deprecated reveals it, selected by default
+            vm.IncludeDeprecated = true;
+
+            Assert.That(vm.RequirementsSpecifications.Select(x => x.RequirementsSpecification), Does.Contain(deprecatedSpec));
+            Assert.IsTrue(vm.RequirementsSpecifications.All(x => x.IsSelected));
+        }
+
+        [Test]
+        public async Task VerifyThatPreviewWithoutSelectedSpecificationIsBlocked()
+        {
+            var spec = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "spec", Name = "Specification" };
+            this.iteration.RequirementsSpecification.Add(spec);
+
+            var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
+
+            vm.SelectedIteration = vm.Iterations.First();
+
+            foreach (var row in vm.RequirementsSpecifications)
+            {
+                row.IsSelected = false;
+            }
+
+            await vm.PreviewSpecObjectTypesCommand.Execute();
+
+            Assert.IsEmpty(vm.SpecObjectTypesPreview);
+            Assert.That(vm.ErrorMessage, Is.EqualTo("Select at least one requirements specification to preview."));
+        }
+
+        [Test]
         public async Task VeriyThatOkCommandWorks()
         {
+            var spec = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "spec", Name = "Specification" };
+            this.iteration.RequirementsSpecification.Add(spec);
+
             var vm = new ReqIfExportDialogViewModel(new List<ISession> { this.session.Object }, new List<Iteration> { this.iteration }, this.fileDialogService.Object, this.serializer.Object);
 
             this.fileDialogService.Setup(

--- a/Requirements.Tests/ReqIF/AttributeDefinitionMappingRowViewModelTestFixture.cs
+++ b/Requirements.Tests/ReqIF/AttributeDefinitionMappingRowViewModelTestFixture.cs
@@ -58,10 +58,10 @@ namespace CDP4Requirements.Tests.ReqIF
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(AttributeDefinitionMapKind.FIRST_DEFINITION, new AttributeDefinitionMappingRowViewModel(textDefinition, null, () => { }).AttributeDefinitionMapKind);
-                Assert.AreEqual(AttributeDefinitionMapKind.NAME, new AttributeDefinitionMappingRowViewModel(nameDefinition, null, () => { }).AttributeDefinitionMapKind);
-                Assert.AreEqual(AttributeDefinitionMapKind.SHORTNAME, new AttributeDefinitionMappingRowViewModel(foreignIdDefinition, null, () => { }).AttributeDefinitionMapKind);
-                Assert.AreEqual(AttributeDefinitionMapKind.NONE, new AttributeDefinitionMappingRowViewModel(otherDefinition, null, () => { }).AttributeDefinitionMapKind);
+                Assert.That(new AttributeDefinitionMappingRowViewModel(textDefinition, null, () => { }).AttributeDefinitionMapKind, Is.EqualTo(AttributeDefinitionMapKind.FIRST_DEFINITION));
+                Assert.That(new AttributeDefinitionMappingRowViewModel(nameDefinition, null, () => { }).AttributeDefinitionMapKind, Is.EqualTo(AttributeDefinitionMapKind.NAME));
+                Assert.That(new AttributeDefinitionMappingRowViewModel(foreignIdDefinition, null, () => { }).AttributeDefinitionMapKind, Is.EqualTo(AttributeDefinitionMapKind.SHORTNAME));
+                Assert.That(new AttributeDefinitionMappingRowViewModel(otherDefinition, null, () => { }).AttributeDefinitionMapKind, Is.EqualTo(AttributeDefinitionMapKind.NONE));
             });
         }
     }

--- a/Requirements.Tests/ReqIF/AttributeDefinitionMappingRowViewModelTestFixture.cs
+++ b/Requirements.Tests/ReqIF/AttributeDefinitionMappingRowViewModelTestFixture.cs
@@ -1,0 +1,65 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="AttributeDefinitionMappingRowViewModelTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Requirements.Tests.ReqIF
+{
+    using System.Reactive.Concurrency;
+
+    using CDP4Requirements.ReqIFDal;
+    using CDP4Requirements.ViewModels;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    using ReqIFSharp;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="AttributeDefinitionMappingRowViewModel"/> class
+    /// </summary>
+    [TestFixture]
+    public class AttributeDefinitionMappingRowViewModelTestFixture
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+        }
+
+        [Test]
+        public void VerifyThatReservedReqIfNamesArePreMapped()
+        {
+            var textDefinition = new AttributeDefinitionXHTML { LongName = ThingToReqIfMapper.RequirementTextXhtmlAttributeDefName };
+            var nameDefinition = new AttributeDefinitionString { LongName = ThingToReqIfMapper.ReqIfNameAttributeDefName };
+            var foreignIdDefinition = new AttributeDefinitionString { LongName = ThingToReqIfMapper.ReqIfForeignIdAttributeDefName };
+            var otherDefinition = new AttributeDefinitionString { LongName = "Something else" };
+
+            Assert.AreEqual(AttributeDefinitionMapKind.FIRST_DEFINITION, new AttributeDefinitionMappingRowViewModel(textDefinition, null, () => { }).AttributeDefinitionMapKind);
+            Assert.AreEqual(AttributeDefinitionMapKind.NAME, new AttributeDefinitionMappingRowViewModel(nameDefinition, null, () => { }).AttributeDefinitionMapKind);
+            Assert.AreEqual(AttributeDefinitionMapKind.SHORTNAME, new AttributeDefinitionMappingRowViewModel(foreignIdDefinition, null, () => { }).AttributeDefinitionMapKind);
+            Assert.AreEqual(AttributeDefinitionMapKind.NONE, new AttributeDefinitionMappingRowViewModel(otherDefinition, null, () => { }).AttributeDefinitionMapKind);
+        }
+    }
+}

--- a/Requirements.Tests/ReqIF/AttributeDefinitionMappingRowViewModelTestFixture.cs
+++ b/Requirements.Tests/ReqIF/AttributeDefinitionMappingRowViewModelTestFixture.cs
@@ -56,10 +56,13 @@ namespace CDP4Requirements.Tests.ReqIF
             var foreignIdDefinition = new AttributeDefinitionString { LongName = ThingToReqIfMapper.ReqIfForeignIdAttributeDefName };
             var otherDefinition = new AttributeDefinitionString { LongName = "Something else" };
 
-            Assert.AreEqual(AttributeDefinitionMapKind.FIRST_DEFINITION, new AttributeDefinitionMappingRowViewModel(textDefinition, null, () => { }).AttributeDefinitionMapKind);
-            Assert.AreEqual(AttributeDefinitionMapKind.NAME, new AttributeDefinitionMappingRowViewModel(nameDefinition, null, () => { }).AttributeDefinitionMapKind);
-            Assert.AreEqual(AttributeDefinitionMapKind.SHORTNAME, new AttributeDefinitionMappingRowViewModel(foreignIdDefinition, null, () => { }).AttributeDefinitionMapKind);
-            Assert.AreEqual(AttributeDefinitionMapKind.NONE, new AttributeDefinitionMappingRowViewModel(otherDefinition, null, () => { }).AttributeDefinitionMapKind);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(AttributeDefinitionMapKind.FIRST_DEFINITION, new AttributeDefinitionMappingRowViewModel(textDefinition, null, () => { }).AttributeDefinitionMapKind);
+                Assert.AreEqual(AttributeDefinitionMapKind.NAME, new AttributeDefinitionMappingRowViewModel(nameDefinition, null, () => { }).AttributeDefinitionMapKind);
+                Assert.AreEqual(AttributeDefinitionMapKind.SHORTNAME, new AttributeDefinitionMappingRowViewModel(foreignIdDefinition, null, () => { }).AttributeDefinitionMapKind);
+                Assert.AreEqual(AttributeDefinitionMapKind.NONE, new AttributeDefinitionMappingRowViewModel(otherDefinition, null, () => { }).AttributeDefinitionMapKind);
+            });
         }
     }
 }

--- a/Requirements.Tests/ReqIF/ParameterTypeMappingDialogTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ParameterTypeMappingDialogTestFixture.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterTypeMappingDialogTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
 //
@@ -29,6 +29,7 @@ namespace CDP4Requirements.Tests.ReqIF
     using System.Collections.Generic;
     using System.Linq;
     using System.Reactive.Linq;
+    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
 
     using CDP4Common.CommonData;
@@ -181,6 +182,20 @@ namespace CDP4Requirements.Tests.ReqIF
         }
 
         [Test]
+        public void VerifyThatEnumValueRowsHaveNoCreateCommands()
+        {
+            var enumRow = this.dialog.MappingRows.First(x => x.Identifiable == this.enumDatadef);
+
+            // the enumeration datatype row itself can create an Enumeration Parameter Type
+            this.dialog.SelectedRow = enumRow;
+            Assert.AreEqual(1, this.dialog.CreateParameterTypeCommands.Count);
+
+            // but its enum-value child rows (the literals) cannot create a parameter type
+            this.dialog.SelectedRow = enumRow.EnumValue.First();
+            Assert.AreEqual(0, this.dialog.CreateParameterTypeCommands.Count);
+        }
+
+        [Test]
         public void VerifyThatCreateGenericParameterTypeWorks()
         {
             this.thingDialogNavigationService.Setup(
@@ -206,6 +221,41 @@ namespace CDP4Requirements.Tests.ReqIF
 
             this.thingDialogNavigationService.Verify(
                 x => x.Navigate(It.IsAny<Thing>(), It.IsAny<IThingTransaction>(), this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, null, null));
+        }
+
+        [Test]
+        public void VerifyThatCreatedEnumValueDefinitionShortNamesAreValidAndUnique()
+        {
+            var enumDatatypeDefinition = new DatatypeDefinitionEnumeration { LongName = "T_LegalObligation" };
+            enumDatatypeDefinition.SpecifiedValues.Add(new EnumValue { LongName = "mandatory (>= 1)", Properties = new EmbeddedValue { Key = 1, OtherContent = "Other content for: mandatory (>= 1)" } });
+            enumDatatypeDefinition.SpecifiedValues.Add(new EnumValue { LongName = "mandatory (== 1)", Properties = new EmbeddedValue { Key = 2, OtherContent = "Other content for: mandatory (== 1)" } });
+            enumDatatypeDefinition.SpecifiedValues.Add(new EnumValue { LongName = "not applicable", Properties = new EmbeddedValue { Key = 3, OtherContent = "Other content for: not applicable" } });
+            enumDatatypeDefinition.SpecifiedValues.Add(new EnumValue { LongName = "ordinary", Properties = new EmbeddedValue { Key = 4, OtherContent = "Other content for: ordinary" } });
+
+            EnumerationParameterType capturedParameterType = null;
+
+            this.thingDialogNavigationService.Setup(
+                    x => x.Navigate(It.IsAny<ParameterType>(), It.IsAny<IThingTransaction>(), this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, null, null))
+                .Callback<Thing, IThingTransaction, ISession, bool, ThingDialogKind, IThingDialogNavigationService, Thing, IEnumerable<Thing>>(
+                    (thing, transaction, session, isRoot, dialogKind, service, container, chain) => capturedParameterType = thing as EnumerationParameterType)
+                .Returns(false);
+
+            var dialog = new ParameterTypeMappingDialogViewModel(this.reqIf.Lang, new DatatypeDefinition[] { enumDatatypeDefinition }, null, this.iteration, this.session.Object, this.thingDialogNavigationService.Object);
+
+            dialog.SelectedRow = dialog.MappingRows.First(x => x.Identifiable == enumDatatypeDefinition);
+            dialog.CreateParameterTypeCommands.First().MenuCommand.Execute(null);
+
+            Assert.IsNotNull(capturedParameterType);
+
+            var shortNamePattern = new Regex("^[a-zA-Z0-9_]+$");
+            var shortNames = capturedParameterType.ValueDefinition.Select(x => x.ShortName).ToList();
+
+            Assert.That(shortNames, Has.All.Matches<string>(x => shortNamePattern.IsMatch(x)), "all short-names must be valid");
+            Assert.That(shortNames.Distinct().Count(), Is.EqualTo(shortNames.Count), "short-names must be unique");
+            Assert.That(shortNames, Has.None.Contains("Other content"), "the ReqIF OTHER-CONTENT placeholder must not be used as short-name");
+
+            // the human-readable name is preserved
+            Assert.That(capturedParameterType.ValueDefinition.Select(x => x.Name), Does.Contain("mandatory (>= 1)"));
         }
 
         [Test]

--- a/Requirements.Tests/ReqIF/ParameterTypeMappingDialogTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ParameterTypeMappingDialogTestFixture.cs
@@ -169,16 +169,16 @@ namespace CDP4Requirements.Tests.ReqIF
         public void VerifyThatMenuIsPopulated()
         {
             this.dialog.SelectedRow = this.dialog.MappingRows.First(x => x.Identifiable == this.stringDatadef);
-            Assert.AreEqual(4, this.dialog.CreateParameterTypeCommands.Count);
+            Assert.That(this.dialog.CreateParameterTypeCommands, Has.Count.EqualTo(4));
 
             this.dialog.SelectedRow = this.dialog.MappingRows.First(x => x.Identifiable == this.boolDatadef);
-            Assert.AreEqual(1, this.dialog.CreateParameterTypeCommands.Count);
+            Assert.That(this.dialog.CreateParameterTypeCommands, Has.Count.EqualTo(1));
 
             this.dialog.SelectedRow = this.dialog.MappingRows.First(x => x.Identifiable == this.enumDatadef);
-            Assert.AreEqual(1, this.dialog.CreateParameterTypeCommands.Count);
+            Assert.That(this.dialog.CreateParameterTypeCommands, Has.Count.EqualTo(1));
 
             this.dialog.SelectedRow = this.dialog.MappingRows.First(x => x.Identifiable == this.dateDatadef);
-            Assert.AreEqual(3, this.dialog.CreateParameterTypeCommands.Count);
+            Assert.That(this.dialog.CreateParameterTypeCommands, Has.Count.EqualTo(3));
         }
 
         [Test]
@@ -188,11 +188,11 @@ namespace CDP4Requirements.Tests.ReqIF
 
             // the enumeration datatype row itself can create an Enumeration Parameter Type
             this.dialog.SelectedRow = enumRow;
-            Assert.AreEqual(1, this.dialog.CreateParameterTypeCommands.Count);
+            Assert.That(this.dialog.CreateParameterTypeCommands, Has.Count.EqualTo(1));
 
             // but its enum-value child rows (the literals) cannot create a parameter type
             this.dialog.SelectedRow = enumRow.EnumValue.First();
-            Assert.AreEqual(0, this.dialog.CreateParameterTypeCommands.Count);
+            Assert.That(this.dialog.CreateParameterTypeCommands, Has.Count.EqualTo(0));
         }
 
         [Test]
@@ -245,7 +245,7 @@ namespace CDP4Requirements.Tests.ReqIF
             dialog.SelectedRow = dialog.MappingRows.First(x => x.Identifiable == enumDatatypeDefinition);
             dialog.CreateParameterTypeCommands.First().MenuCommand.Execute(null);
 
-            Assert.IsNotNull(capturedParameterType);
+            Assert.That(capturedParameterType, Is.Not.Null);
 
             var shortNamePattern = new Regex("^[a-zA-Z0-9_]+$");
             var shortNames = capturedParameterType.ValueDefinition.Select(x => x.ShortName).ToList();
@@ -279,7 +279,7 @@ namespace CDP4Requirements.Tests.ReqIF
         public async Task VerifyThatCancelCommandWorks()
         {
             await this.dialog.CancelCommand.Execute();
-            Assert.IsFalse(this.dialog.DialogResult.Result.Value);
+            Assert.That(this.dialog.DialogResult.Result.Value, Is.False);
         }
 
         [Test]
@@ -293,7 +293,7 @@ namespace CDP4Requirements.Tests.ReqIF
             }
 
             await this.dialog.NextCommand.Execute();
-            Assert.IsTrue(this.dialog.DialogResult.Result.Value);
+            Assert.That(this.dialog.DialogResult.Result.Value, Is.True);
         }
     }
 }

--- a/Requirements.Tests/ReqIF/ParameterTypeMappingDialogTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ParameterTypeMappingDialogTestFixture.cs
@@ -250,12 +250,15 @@ namespace CDP4Requirements.Tests.ReqIF
             var shortNamePattern = new Regex("^[a-zA-Z0-9_]+$");
             var shortNames = capturedParameterType.ValueDefinition.Select(x => x.ShortName).ToList();
 
-            Assert.That(shortNames, Has.All.Matches<string>(x => shortNamePattern.IsMatch(x)), "all short-names must be valid");
-            Assert.That(shortNames.Distinct().Count(), Is.EqualTo(shortNames.Count), "short-names must be unique");
-            Assert.That(shortNames, Has.None.Contains("Other content"), "the ReqIF OTHER-CONTENT placeholder must not be used as short-name");
+            Assert.Multiple(() =>
+            {
+                Assert.That(shortNames, Has.All.Matches<string>(x => shortNamePattern.IsMatch(x)), "all short-names must be valid");
+                Assert.That(shortNames.Distinct().Count(), Is.EqualTo(shortNames.Count), "short-names must be unique");
+                Assert.That(shortNames, Has.None.Contains("Other content"), "the ReqIF OTHER-CONTENT placeholder must not be used as short-name");
 
-            // the human-readable name is preserved
-            Assert.That(capturedParameterType.ValueDefinition.Select(x => x.Name), Does.Contain("mandatory (>= 1)"));
+                // the human-readable name is preserved
+                Assert.That(capturedParameterType.ValueDefinition.Select(x => x.Name), Does.Contain("mandatory (>= 1)"));
+            });
         }
 
         [Test]

--- a/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
@@ -318,7 +318,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
+            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
@@ -399,7 +399,7 @@ namespace CDP4Requirements.Tests
         {
             var builder = new ReqIFBuilder();
 
-            var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true);
+            var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true, null, ReqIfExportProfile.DoorsCapella);
 
             Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "an XHTML datatype is exported");
 
@@ -447,7 +447,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
+            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 5 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 3 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
@@ -472,7 +472,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
+            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
@@ -497,7 +497,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
+            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
@@ -522,7 +522,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
+            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
@@ -547,7 +547,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
+            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type

--- a/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
@@ -318,17 +318,17 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(reqif);
+                Assert.That(reqif, Is.Not.Null);
 
                 // 2 + 1 extra datatype for requriement text
-                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-                Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-                Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
-                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
-                Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-                Assert.AreEqual(1, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+                Assert.That(reqif.CoreContent.DataTypes, Has.Count.EqualTo(3)); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.That(reqif.CoreContent.SpecObjects, Has.Count.EqualTo(6)); // 4 requirements + 2 groups
+                Assert.That(reqif.CoreContent.Specifications, Has.Count.EqualTo(2)); // 2 specification
+                Assert.That(reqif.CoreContent.SpecTypes, Has.Count.EqualTo(5)); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.That(reqif.CoreContent.SpecRelations, Has.Count.EqualTo(3)); // 3 specRelation from 3 relationship
+                Assert.That(reqif.CoreContent.SpecRelationGroups, Has.Count.EqualTo(1)); // 1 RelationGroup from 1 binaryRelationship
 
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Single().SpecRelations);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.Single().SpecRelations, Is.Not.Empty);
             });
 
             var serializer = new ReqIFSerializer(false);
@@ -363,10 +363,10 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(1, requirementTypes.Count);
-                Assert.AreEqual(this.parameRule.ShortName, requirementType?.LongName);
-                Assert.Contains(this.booleanParameterType.Iid.ToString(), datatypeIdentifiers);
-                Assert.Contains(textParameterType.Iid.ToString(), datatypeIdentifiers);
+                Assert.That(requirementTypes, Has.Count.EqualTo(1));
+                Assert.That(requirementType?.LongName, Is.EqualTo(this.parameRule.ShortName));
+                Assert.That(datatypeIdentifiers, Does.Contain(this.booleanParameterType.Iid.ToString()));
+                Assert.That(datatypeIdentifiers, Does.Contain(textParameterType.Iid.ToString()));
             });
         }
 
@@ -381,11 +381,11 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsFalse(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "no XHTML datatype in the OMG profile");
-                Assert.IsEmpty(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueXHTML>(), "no XHTML values in the OMG profile");
-                Assert.Contains(ThingToReqIfMapper.ShortNameAttributeDefName, attributeNames);
-                Assert.Contains(ThingToReqIfMapper.NameAttributeDefName, attributeNames);
-                Assert.IsFalse(attributeNames.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName), "the OMG profile does not use the reserved names");
+                Assert.That(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), Is.False, "no XHTML datatype in the OMG profile");
+                Assert.That(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueXHTML>(), Is.Empty, "no XHTML values in the OMG profile");
+                Assert.That(attributeNames, Does.Contain(ThingToReqIfMapper.ShortNameAttributeDefName));
+                Assert.That(attributeNames, Does.Contain(ThingToReqIfMapper.NameAttributeDefName));
+                Assert.That(attributeNames.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName), Is.False, "the OMG profile does not use the reserved names");
             });
         }
 
@@ -400,10 +400,10 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "the DOORS/Capella profile exports an XHTML datatype");
-                Assert.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName, attributeNames);
-                Assert.Contains(ThingToReqIfMapper.ReqIfForeignIdAttributeDefName, attributeNames);
-                Assert.IsFalse(attributeNames.Contains(ThingToReqIfMapper.NameAttributeDefName), "the DOORS/Capella profile uses the reserved names instead of the native ones");
+                Assert.That(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), Is.True, "the DOORS/Capella profile exports an XHTML datatype");
+                Assert.That(attributeNames, Does.Contain(ThingToReqIfMapper.ReqIfNameAttributeDefName));
+                Assert.That(attributeNames, Does.Contain(ThingToReqIfMapper.ReqIfForeignIdAttributeDefName));
+                Assert.That(attributeNames.Contains(ThingToReqIfMapper.NameAttributeDefName), Is.False, "the DOORS/Capella profile uses the reserved names instead of the native ones");
             });
         }
 
@@ -421,13 +421,13 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "an XHTML datatype is exported");
-                Assert.IsNotEmpty(xhtmlValues, "requirement text is also exported as XHTML");
-                Assert.IsTrue(xhtmlValues.Any(v => v.TheValue.Contains("def1")), "the requirement definition content is wrapped in the XHTML value");
-                Assert.IsTrue(xhtmlValues.All(v => v.TheValue.Contains("http://www.w3.org/1999/xhtml")), "the XHTML value declares the XHTML namespace so it is valid");
+                Assert.That(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), Is.True, "an XHTML datatype is exported");
+                Assert.That(xhtmlValues, Is.Not.Empty, "requirement text is also exported as XHTML");
+                Assert.That(xhtmlValues.Any(v => v.TheValue.Contains("def1")), Is.True, "the requirement definition content is wrapped in the XHTML value");
+                Assert.That(xhtmlValues.All(v => v.TheValue.Contains("http://www.w3.org/1999/xhtml")), Is.True, "the XHTML value declares the XHTML namespace so it is valid");
 
                 // the plain-text string representation is kept so the COMET importer keeps round-tripping
-                Assert.IsTrue(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueString>().Any(v => v.TheValue == "def1"));
+                Assert.That(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueString>().Any(v => v.TheValue == "def1"), Is.True);
             });
 
             // the produced document is valid ReqIF: it serializes and re-deserializes without error
@@ -439,8 +439,8 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotEmpty(reloadedXhtml);
-                Assert.IsTrue(reloadedXhtml.Any(v => v.TheValue.Contains("def1")));
+                Assert.That(reloadedXhtml, Is.Not.Empty);
+                Assert.That(reloadedXhtml.Any(v => v.TheValue.Contains("def1")), Is.True);
             });
         }
 
@@ -453,9 +453,9 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(reqif);
-                Assert.AreEqual(1, reqif.CoreContent.Specifications.Count); // only the single selected specification
-                Assert.AreEqual(this.reqSpec.Iid.ToString(), reqif.CoreContent.Specifications.Single().Identifier);
+                Assert.That(reqif, Is.Not.Null);
+                Assert.That(reqif.CoreContent.Specifications, Has.Count.EqualTo(1)); // only the single selected specification
+                Assert.That(reqif.CoreContent.Specifications.Single().Identifier, Is.EqualTo(this.reqSpec.Iid.ToString()));
             });
         }
 
@@ -468,18 +468,18 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(reqif);
+                Assert.That(reqif, Is.Not.Null);
 
                 // 2 + 1 extra datatype for requriement text
-                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-                Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 5 requirements + 2 groups
-                Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 3 specification
-                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
-                Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 4 specRelation from 3 relationship
-                Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 2 RelationGroup from 1 binaryRelationship
+                Assert.That(reqif.CoreContent.DataTypes, Has.Count.EqualTo(3)); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.That(reqif.CoreContent.SpecObjects, Has.Count.EqualTo(7)); // 5 requirements + 2 groups
+                Assert.That(reqif.CoreContent.Specifications, Has.Count.EqualTo(3)); // 3 specification
+                Assert.That(reqif.CoreContent.SpecTypes, Has.Count.EqualTo(5)); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.That(reqif.CoreContent.SpecRelations, Has.Count.EqualTo(4)); // 4 specRelation from 3 relationship
+                Assert.That(reqif.CoreContent.SpecRelationGroups, Has.Count.EqualTo(2)); // 2 RelationGroup from 1 binaryRelationship
 
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.First().SpecRelations, Is.Not.Empty);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations, Is.Not.Empty);
             });
 
             var serializer = new ReqIFSerializer(false);
@@ -497,18 +497,18 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(reqif);
+                Assert.That(reqif, Is.Not.Null);
 
                 // 2 + 1 extra datatype for requriement text
-                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-                Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-                Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
-                Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-                Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+                Assert.That(reqif.CoreContent.DataTypes, Has.Count.EqualTo(3)); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.That(reqif.CoreContent.SpecObjects, Has.Count.EqualTo(7)); // 4 requirements + 2 groups
+                Assert.That(reqif.CoreContent.Specifications, Has.Count.EqualTo(3)); // 2 specification
+                Assert.That(reqif.CoreContent.SpecTypes, Has.Count.EqualTo(5)); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.That(reqif.CoreContent.SpecRelations, Has.Count.EqualTo(4)); // 3 specRelation from 3 relationship
+                Assert.That(reqif.CoreContent.SpecRelationGroups, Has.Count.EqualTo(2)); // 1 RelationGroup from 1 binaryRelationship
 
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.First().SpecRelations, Is.Not.Empty);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations, Is.Not.Empty);
             });
 
             var serializer = new ReqIFSerializer(false);
@@ -526,18 +526,18 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(reqif);
+                Assert.That(reqif, Is.Not.Null);
 
                 // 2 + 1 extra datatype for requriement text
-                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-                Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-                Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
-                Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-                Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+                Assert.That(reqif.CoreContent.DataTypes, Has.Count.EqualTo(3)); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.That(reqif.CoreContent.SpecObjects, Has.Count.EqualTo(7)); // 4 requirements + 2 groups
+                Assert.That(reqif.CoreContent.Specifications, Has.Count.EqualTo(3)); // 2 specification
+                Assert.That(reqif.CoreContent.SpecTypes, Has.Count.EqualTo(5)); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.That(reqif.CoreContent.SpecRelations, Has.Count.EqualTo(4)); // 3 specRelation from 3 relationship
+                Assert.That(reqif.CoreContent.SpecRelationGroups, Has.Count.EqualTo(2)); // 1 RelationGroup from 1 binaryRelationship
 
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.First().SpecRelations, Is.Not.Empty);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations, Is.Not.Empty);
             });
 
             var serializer = new ReqIFSerializer(false);
@@ -555,18 +555,18 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(reqif);
+                Assert.That(reqif, Is.Not.Null);
 
                 // 2 + 1 extra datatype for requriement text
-                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-                Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-                Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
-                Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-                Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+                Assert.That(reqif.CoreContent.DataTypes, Has.Count.EqualTo(3)); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.That(reqif.CoreContent.SpecObjects, Has.Count.EqualTo(6)); // 4 requirements + 2 groups
+                Assert.That(reqif.CoreContent.Specifications, Has.Count.EqualTo(3)); // 2 specification
+                Assert.That(reqif.CoreContent.SpecTypes, Has.Count.EqualTo(5)); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.That(reqif.CoreContent.SpecRelations, Has.Count.EqualTo(3)); // 3 specRelation from 3 relationship
+                Assert.That(reqif.CoreContent.SpecRelationGroups, Has.Count.EqualTo(2)); // 1 RelationGroup from 1 binaryRelationship
 
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
-                Assert.IsEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.First().SpecRelations, Is.Not.Empty);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations, Is.Empty);
             });
 
             var serializer = new ReqIFSerializer(false);
@@ -584,17 +584,17 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(reqif);
+                Assert.That(reqif, Is.Not.Null);
 
                 // 2 + 1 extra datatype for requriement text
-                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-                Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-                Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
-                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
-                Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-                Assert.AreEqual(1, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+                Assert.That(reqif.CoreContent.DataTypes, Has.Count.EqualTo(3)); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.That(reqif.CoreContent.SpecObjects, Has.Count.EqualTo(6)); // 4 requirements + 2 groups
+                Assert.That(reqif.CoreContent.Specifications, Has.Count.EqualTo(2)); // 2 specification
+                Assert.That(reqif.CoreContent.SpecTypes, Has.Count.EqualTo(5)); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.That(reqif.CoreContent.SpecRelations, Has.Count.EqualTo(3)); // 3 specRelation from 3 relationship
+                Assert.That(reqif.CoreContent.SpecRelationGroups, Has.Count.EqualTo(1)); // 1 RelationGroup from 1 binaryRelationship
 
-                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Single().SpecRelations);
+                Assert.That(reqif.CoreContent.SpecRelationGroups.Single().SpecRelations, Is.Not.Empty);
             });
 
             var serializer = new ReqIFSerializer(false);
@@ -617,10 +617,10 @@ namespace CDP4Requirements.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(1, requirementSpecObjectTypes.Count);
+                Assert.That(requirementSpecObjectTypes, Has.Count.EqualTo(1));
 
                 // the attribute definition created for the requirement's parameter value carries the parameter type name
-                Assert.IsTrue(requirementSpecObjectTypes.Any(t => t.SpecAttributes.Any(x => x.LongName == this.booleanParameterType.ShortName)));
+                Assert.That(requirementSpecObjectTypes.Any(t => t.SpecAttributes.Any(x => x.LongName == this.booleanParameterType.ShortName)), Is.True);
             });
         }
 

--- a/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
@@ -315,17 +315,21 @@ namespace CDP4Requirements.Tests
             var builder = new ReqIFBuilder();
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration);
-            Assert.IsNotNull(reqif);
 
-            // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-            Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-            Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
-            Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-            Assert.AreEqual(1, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(reqif);
 
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Single().SpecRelations);
+                // 2 + 1 extra datatype for requriement text
+                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
+                Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
+                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
+                Assert.AreEqual(1, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Single().SpecRelations);
+            });
 
             var serializer = new ReqIFSerializer(false);
             serializer.Serialize(reqif, @"output.xml", (o, e) => { throw new Exception(); });
@@ -352,15 +356,18 @@ namespace CDP4Requirements.Tests
                 .Where(x => !x.LongName.StartsWith(ThingToReqIfMapper.GroupNamePrefix))
                 .ToList();
 
-            Assert.AreEqual(1, requirementTypes.Count);
-
-            var requirementType = requirementTypes.Single();
-            Assert.AreEqual(this.parameRule.ShortName, requirementType.LongName);
+            var requirementType = requirementTypes.FirstOrDefault();
 
             // the single collapsed type carries attribute definitions for BOTH parameter types (the union)
-            var datatypeIdentifiers = requirementType.SpecAttributes.Select(x => x.DatatypeDefinition.Identifier).ToList();
-            Assert.Contains(this.booleanParameterType.Iid.ToString(), datatypeIdentifiers);
-            Assert.Contains(textParameterType.Iid.ToString(), datatypeIdentifiers);
+            var datatypeIdentifiers = requirementType?.SpecAttributes.Select(x => x.DatatypeDefinition.Identifier).ToArray() ?? Array.Empty<string>();
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(1, requirementTypes.Count);
+                Assert.AreEqual(this.parameRule.ShortName, requirementType?.LongName);
+                Assert.Contains(this.booleanParameterType.Iid.ToString(), datatypeIdentifiers);
+                Assert.Contains(textParameterType.Iid.ToString(), datatypeIdentifiers);
+            });
         }
 
         [Test]
@@ -370,13 +377,16 @@ namespace CDP4Requirements.Tests
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true, null, ReqIfExportProfile.Omg);
 
-            Assert.IsFalse(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "no XHTML datatype in the OMG profile");
-            Assert.IsEmpty(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueXHTML>(), "no XHTML values in the OMG profile");
-
             var attributeNames = reqif.CoreContent.SpecTypes.SelectMany(st => st.SpecAttributes).Select(a => a.LongName).ToList();
-            Assert.Contains(ThingToReqIfMapper.ShortNameAttributeDefName, attributeNames);
-            Assert.Contains(ThingToReqIfMapper.NameAttributeDefName, attributeNames);
-            Assert.IsFalse(attributeNames.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName), "the OMG profile does not use the reserved names");
+
+            Assert.Multiple(() =>
+            {
+                Assert.IsFalse(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "no XHTML datatype in the OMG profile");
+                Assert.IsEmpty(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueXHTML>(), "no XHTML values in the OMG profile");
+                Assert.Contains(ThingToReqIfMapper.ShortNameAttributeDefName, attributeNames);
+                Assert.Contains(ThingToReqIfMapper.NameAttributeDefName, attributeNames);
+                Assert.IsFalse(attributeNames.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName), "the OMG profile does not use the reserved names");
+            });
         }
 
         [Test]
@@ -386,12 +396,15 @@ namespace CDP4Requirements.Tests
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true, null, ReqIfExportProfile.DoorsCapella);
 
-            Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "the DOORS/Capella profile exports an XHTML datatype");
-
             var attributeNames = reqif.CoreContent.SpecTypes.SelectMany(st => st.SpecAttributes).Select(a => a.LongName).ToList();
-            Assert.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName, attributeNames);
-            Assert.Contains(ThingToReqIfMapper.ReqIfForeignIdAttributeDefName, attributeNames);
-            Assert.IsFalse(attributeNames.Contains(ThingToReqIfMapper.NameAttributeDefName), "the DOORS/Capella profile uses the reserved names instead of the native ones");
+
+            Assert.Multiple(() =>
+            {
+                Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "the DOORS/Capella profile exports an XHTML datatype");
+                Assert.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName, attributeNames);
+                Assert.Contains(ThingToReqIfMapper.ReqIfForeignIdAttributeDefName, attributeNames);
+                Assert.IsFalse(attributeNames.Contains(ThingToReqIfMapper.NameAttributeDefName), "the DOORS/Capella profile uses the reserved names instead of the native ones");
+            });
         }
 
         [Test]
@@ -401,19 +414,21 @@ namespace CDP4Requirements.Tests
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true, null, ReqIfExportProfile.DoorsCapella);
 
-            Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "an XHTML datatype is exported");
-
             var xhtmlValues = reqif.CoreContent.SpecObjects
                 .SelectMany(specObject => specObject.Values)
                 .OfType<AttributeValueXHTML>()
                 .ToList();
 
-            Assert.IsNotEmpty(xhtmlValues, "requirement text is also exported as XHTML");
-            Assert.IsTrue(xhtmlValues.Any(v => v.TheValue.Contains("def1")), "the requirement definition content is wrapped in the XHTML value");
-            Assert.IsTrue(xhtmlValues.All(v => v.TheValue.Contains("http://www.w3.org/1999/xhtml")), "the XHTML value declares the XHTML namespace so it is valid");
+            Assert.Multiple(() =>
+            {
+                Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "an XHTML datatype is exported");
+                Assert.IsNotEmpty(xhtmlValues, "requirement text is also exported as XHTML");
+                Assert.IsTrue(xhtmlValues.Any(v => v.TheValue.Contains("def1")), "the requirement definition content is wrapped in the XHTML value");
+                Assert.IsTrue(xhtmlValues.All(v => v.TheValue.Contains("http://www.w3.org/1999/xhtml")), "the XHTML value declares the XHTML namespace so it is valid");
 
-            // the plain-text string representation is kept so the COMET importer keeps round-tripping
-            Assert.IsTrue(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueString>().Any(v => v.TheValue == "def1"));
+                // the plain-text string representation is kept so the COMET importer keeps round-tripping
+                Assert.IsTrue(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueString>().Any(v => v.TheValue == "def1"));
+            });
 
             // the produced document is valid ReqIF: it serializes and re-deserializes without error
             var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "xhtml_roundtrip.reqif");
@@ -422,8 +437,11 @@ namespace CDP4Requirements.Tests
             var reloaded = new ReqIFDeserializer().Deserialize(path, false, null).Single();
             var reloadedXhtml = reloaded.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueXHTML>().ToList();
 
-            Assert.IsNotEmpty(reloadedXhtml);
-            Assert.IsTrue(reloadedXhtml.Any(v => v.TheValue.Contains("def1")));
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotEmpty(reloadedXhtml);
+                Assert.IsTrue(reloadedXhtml.Any(v => v.TheValue.Contains("def1")));
+            });
         }
 
         [Test]
@@ -432,10 +450,13 @@ namespace CDP4Requirements.Tests
             var builder = new ReqIFBuilder();
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration, false, new[] { this.reqSpec });
-            Assert.IsNotNull(reqif);
 
-            Assert.AreEqual(1, reqif.CoreContent.Specifications.Count); // only the single selected specification
-            Assert.AreEqual(this.reqSpec.Iid.ToString(), reqif.CoreContent.Specifications.Single().Identifier);
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(reqif);
+                Assert.AreEqual(1, reqif.CoreContent.Specifications.Count); // only the single selected specification
+                Assert.AreEqual(this.reqSpec.Iid.ToString(), reqif.CoreContent.Specifications.Single().Identifier);
+            });
         }
 
         [Test]
@@ -444,18 +465,22 @@ namespace CDP4Requirements.Tests
             var builder = new ReqIFBuilder();
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true);
-            Assert.IsNotNull(reqif);
 
-            // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-            Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 5 requirements + 2 groups
-            Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 3 specification
-            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
-            Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 4 specRelation from 3 relationship
-            Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 2 RelationGroup from 1 binaryRelationship
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(reqif);
 
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+                // 2 + 1 extra datatype for requriement text
+                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 5 requirements + 2 groups
+                Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 3 specification
+                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 4 specRelation from 3 relationship
+                Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 2 RelationGroup from 1 binaryRelationship
+
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+            });
 
             var serializer = new ReqIFSerializer(false);
             serializer.Serialize(reqif, @"output.xml", (o, e) => { throw new Exception(); });
@@ -469,18 +494,22 @@ namespace CDP4Requirements.Tests
             this.deprecatedRequirementsSpecification.IsDeprecated = false;
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true);
-            Assert.IsNotNull(reqif);
 
-            // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-            Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-            Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
-            Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-            Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(reqif);
 
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+                // 2 + 1 extra datatype for requriement text
+                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
+                Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
+                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
+                Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+            });
 
             var serializer = new ReqIFSerializer(false);
             serializer.Serialize(reqif, @"output.xml", (o, e) => { throw new Exception(); });
@@ -494,23 +523,27 @@ namespace CDP4Requirements.Tests
             this.deprecatedRequirement.IsDeprecated = false;
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true);
-            Assert.IsNotNull(reqif);
 
-            // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-            Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-            Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
-            Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-            Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(reqif);
 
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+                // 2 + 1 extra datatype for requriement text
+                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
+                Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
+                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
+                Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+            });
 
             var serializer = new ReqIFSerializer(false);
             serializer.Serialize(reqif, @"output.xml", (o, e) => { throw new Exception(); });
         }
-        
+
         [Test]
         public void VerifyThatRequirementSpecificationCanBeExportedIntoReqIF_Default_HavingDeprecatedRequirementsSpecification()
         {
@@ -519,18 +552,22 @@ namespace CDP4Requirements.Tests
             this.deprecatedRequirementsSpecification.IsDeprecated = false;
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration);
-            Assert.IsNotNull(reqif);
 
-            // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-            Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-            Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
-            Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-            Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(reqif);
 
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
-            Assert.IsEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+                // 2 + 1 extra datatype for requriement text
+                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
+                Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
+                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
+                Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.First().SpecRelations);
+                Assert.IsEmpty(reqif.CoreContent.SpecRelationGroups.Skip(1).First().SpecRelations);
+            });
 
             var serializer = new ReqIFSerializer(false);
             serializer.Serialize(reqif, @"output.xml", (o, e) => { throw new Exception(); });
@@ -544,17 +581,21 @@ namespace CDP4Requirements.Tests
             this.deprecatedRequirement.IsDeprecated = false;
 
             var reqif = builder.BuildReqIF(this.session.Object, this.iteration);
-            Assert.IsNotNull(reqif);
 
-            // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
-            Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
-            Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
-            Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
-            Assert.AreEqual(1, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(reqif);
 
-            Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Single().SpecRelations);
+                // 2 + 1 extra datatype for requriement text
+                Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype (OMG default, no XHTML)
+                Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
+                Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
+                Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
+                Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
+                Assert.AreEqual(1, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
+
+                Assert.IsNotEmpty(reqif.CoreContent.SpecRelationGroups.Single().SpecRelations);
+            });
 
             var serializer = new ReqIFSerializer(false);
             serializer.Serialize(reqif, @"output.xml", (o, e) => { throw new Exception(); });
@@ -574,10 +615,13 @@ namespace CDP4Requirements.Tests
                 .Where(x => !x.LongName.StartsWith(ThingToReqIfMapper.GroupNamePrefix))
                 .ToList();
 
-            Assert.AreEqual(1, requirementSpecObjectTypes.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(1, requirementSpecObjectTypes.Count);
 
-            // the attribute definition created for the requirement's parameter value carries the parameter type name
-            Assert.IsTrue(requirementSpecObjectTypes.Single().SpecAttributes.Any(x => x.LongName == this.booleanParameterType.ShortName));
+                // the attribute definition created for the requirement's parameter value carries the parameter type name
+                Assert.IsTrue(requirementSpecObjectTypes.Any(t => t.SpecAttributes.Any(x => x.LongName == this.booleanParameterType.ShortName)));
+            });
         }
 
         [Test]

--- a/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
@@ -26,6 +26,7 @@
 namespace CDP4Requirements.Tests
 {
     using System;
+    using System.IO;
     using System.Linq;
 
     using CDP4Common.CommonData;
@@ -317,7 +318,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
+            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
@@ -331,6 +332,113 @@ namespace CDP4Requirements.Tests
         }
 
         [Test]
+        public void VerifyThatRequirementsWithDifferentParametersShareOneCollapsedType()
+        {
+            // a second requirement whose parameter differs from the boolean one used by all the others
+            var textParameterType = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "text", ShortName = "txt" };
+            this.srdl.ParameterType.Add(textParameterType);
+
+            var requirementWithText = new Requirement(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ReqText", ShortName = "RT" };
+            requirementWithText.Category.Add(this.reqCategory);
+            requirementWithText.ParameterValue.Add(new SimpleParameterValue(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = textParameterType, Value = new ValueArray<string>(new[] { "hello" }) });
+            this.reqSpec.Requirement.Add(requirementWithText);
+
+            var builder = new ReqIFBuilder();
+
+            var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true);
+
+            // all requirements share the same rule-set, so there is exactly ONE requirement SpecObjectType
+            var requirementTypes = reqif.CoreContent.SpecTypes.OfType<SpecObjectType>()
+                .Where(x => !x.LongName.StartsWith(ThingToReqIfMapper.GroupNamePrefix))
+                .ToList();
+
+            Assert.AreEqual(1, requirementTypes.Count);
+
+            var requirementType = requirementTypes.Single();
+            Assert.AreEqual(this.parameRule.ShortName, requirementType.LongName);
+
+            // the single collapsed type carries attribute definitions for BOTH parameter types (the union)
+            var datatypeIdentifiers = requirementType.SpecAttributes.Select(x => x.DatatypeDefinition.Identifier).ToList();
+            Assert.Contains(this.booleanParameterType.Iid.ToString(), datatypeIdentifiers);
+            Assert.Contains(textParameterType.Iid.ToString(), datatypeIdentifiers);
+        }
+
+        [Test]
+        public void VerifyThatOmgProfileExportsNativeNamesAndNoXhtml()
+        {
+            var builder = new ReqIFBuilder();
+
+            var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true, null, ReqIfExportProfile.Omg);
+
+            Assert.IsFalse(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "no XHTML datatype in the OMG profile");
+            Assert.IsEmpty(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueXHTML>(), "no XHTML values in the OMG profile");
+
+            var attributeNames = reqif.CoreContent.SpecTypes.SelectMany(st => st.SpecAttributes).Select(a => a.LongName).ToList();
+            Assert.Contains(ThingToReqIfMapper.ShortNameAttributeDefName, attributeNames);
+            Assert.Contains(ThingToReqIfMapper.NameAttributeDefName, attributeNames);
+            Assert.IsFalse(attributeNames.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName), "the OMG profile does not use the reserved names");
+        }
+
+        [Test]
+        public void VerifyThatDoorsCapellaProfileUsesReservedNamesAndXhtml()
+        {
+            var builder = new ReqIFBuilder();
+
+            var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true, null, ReqIfExportProfile.DoorsCapella);
+
+            Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "the DOORS/Capella profile exports an XHTML datatype");
+
+            var attributeNames = reqif.CoreContent.SpecTypes.SelectMany(st => st.SpecAttributes).Select(a => a.LongName).ToList();
+            Assert.Contains(ThingToReqIfMapper.ReqIfNameAttributeDefName, attributeNames);
+            Assert.Contains(ThingToReqIfMapper.ReqIfForeignIdAttributeDefName, attributeNames);
+            Assert.IsFalse(attributeNames.Contains(ThingToReqIfMapper.NameAttributeDefName), "the DOORS/Capella profile uses the reserved names instead of the native ones");
+        }
+
+        [Test]
+        public void VerifyThatRequirementTextIsExportedAsXhtmlAndRoundtrips()
+        {
+            var builder = new ReqIFBuilder();
+
+            var reqif = builder.BuildReqIF(this.session.Object, this.iteration, true);
+
+            Assert.IsTrue(reqif.CoreContent.DataTypes.OfType<DatatypeDefinitionXHTML>().Any(), "an XHTML datatype is exported");
+
+            var xhtmlValues = reqif.CoreContent.SpecObjects
+                .SelectMany(specObject => specObject.Values)
+                .OfType<AttributeValueXHTML>()
+                .ToList();
+
+            Assert.IsNotEmpty(xhtmlValues, "requirement text is also exported as XHTML");
+            Assert.IsTrue(xhtmlValues.Any(v => v.TheValue.Contains("def1")), "the requirement definition content is wrapped in the XHTML value");
+            Assert.IsTrue(xhtmlValues.All(v => v.TheValue.Contains("http://www.w3.org/1999/xhtml")), "the XHTML value declares the XHTML namespace so it is valid");
+
+            // the plain-text string representation is kept so the COMET importer keeps round-tripping
+            Assert.IsTrue(reqif.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueString>().Any(v => v.TheValue == "def1"));
+
+            // the produced document is valid ReqIF: it serializes and re-deserializes without error
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "xhtml_roundtrip.reqif");
+            new ReqIFSerializer(false).Serialize(reqif, path, (o, e) => throw new Exception());
+
+            var reloaded = new ReqIFDeserializer().Deserialize(path, false, null).Single();
+            var reloadedXhtml = reloaded.CoreContent.SpecObjects.SelectMany(so => so.Values).OfType<AttributeValueXHTML>().ToList();
+
+            Assert.IsNotEmpty(reloadedXhtml);
+            Assert.IsTrue(reloadedXhtml.Any(v => v.TheValue.Contains("def1")));
+        }
+
+        [Test]
+        public void VerifyThatOnlySelectedRequirementsSpecificationsAreExported()
+        {
+            var builder = new ReqIFBuilder();
+
+            var reqif = builder.BuildReqIF(this.session.Object, this.iteration, false, new[] { this.reqSpec });
+            Assert.IsNotNull(reqif);
+
+            Assert.AreEqual(1, reqif.CoreContent.Specifications.Count); // only the single selected specification
+            Assert.AreEqual(this.reqSpec.Iid.ToString(), reqif.CoreContent.Specifications.Single().Identifier);
+        }
+
+        [Test]
         public void VerifyThatRequirementSpecificationCanBeExportedIntoReqIF_IncludingDeprecated()
         {
             var builder = new ReqIFBuilder();
@@ -339,7 +447,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
+            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 5 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 3 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
@@ -364,7 +472,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
+            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
@@ -389,7 +497,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
+            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
@@ -414,7 +522,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
+            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
@@ -439,7 +547,7 @@ namespace CDP4Requirements.Tests
             Assert.IsNotNull(reqif);
 
             // 2 + 1 extra datatype for requriement text
-            Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
+            Assert.AreEqual(4, reqif.CoreContent.DataTypes.Count); // booleanPt, boolean, Text and XHTML datatype
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
             Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type

--- a/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIFBuilderTestFixture.cs
@@ -320,7 +320,7 @@ namespace CDP4Requirements.Tests
             Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(8, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
             Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
             Assert.AreEqual(1, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
 
@@ -342,7 +342,7 @@ namespace CDP4Requirements.Tests
             Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 5 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 3 specification
-            Assert.AreEqual(9, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type,3 Spec type, 1 Relation type, 1 relationGroup type
+            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
             Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 4 specRelation from 3 relationship
             Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 2 RelationGroup from 1 binaryRelationship
 
@@ -367,7 +367,7 @@ namespace CDP4Requirements.Tests
             Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(9, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
             Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
             Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
 
@@ -392,7 +392,7 @@ namespace CDP4Requirements.Tests
             Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
             Assert.AreEqual(7, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(9, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
+            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
             Assert.AreEqual(4, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
             Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
 
@@ -417,7 +417,7 @@ namespace CDP4Requirements.Tests
             Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(3, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(8, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
+            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 1 Spec type, 1 Relation type, 1 relationGroup type
             Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
             Assert.AreEqual(2, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
 
@@ -442,7 +442,7 @@ namespace CDP4Requirements.Tests
             Assert.AreEqual(3, reqif.CoreContent.DataTypes.Count); // booleanPt and boolean and Text datatype
             Assert.AreEqual(6, reqif.CoreContent.SpecObjects.Count); // 4 requirements + 2 groups
             Assert.AreEqual(2, reqif.CoreContent.Specifications.Count); // 2 specification
-            Assert.AreEqual(8, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
+            Assert.AreEqual(5, reqif.CoreContent.SpecTypes.Count); // 1 group type, 1 Req type, 2 Spec type, 1 Relation type, 1 relationGroup type
             Assert.AreEqual(3, reqif.CoreContent.SpecRelations.Count); // 3 specRelation from 3 relationship
             Assert.AreEqual(1, reqif.CoreContent.SpecRelationGroups.Count); // 1 RelationGroup from 1 binaryRelationship
 
@@ -450,6 +450,26 @@ namespace CDP4Requirements.Tests
 
             var serializer = new ReqIFSerializer(false);
             serializer.Serialize(reqif, @"output.xml", (o, e) => { throw new Exception(); });
+        }
+
+        [Test]
+        public void VerifyThatRequirementsWithIdenticalTypeShareASingleSpecObjectType()
+        {
+            // All exported requirements share the same category/rule and parameter type, so they must
+            // collapse onto a single requirement SpecObjectType instead of one per requirement (GH #1487)
+            var builder = new ReqIFBuilder();
+
+            var reqif = builder.BuildReqIF(this.session.Object, this.iteration);
+
+            var requirementSpecObjectTypes = reqif.CoreContent.SpecTypes
+                .OfType<SpecObjectType>()
+                .Where(x => !x.LongName.StartsWith(ThingToReqIfMapper.GroupNamePrefix))
+                .ToList();
+
+            Assert.AreEqual(1, requirementSpecObjectTypes.Count);
+
+            // the attribute definition created for the requirement's parameter value carries the parameter type name
+            Assert.IsTrue(requirementSpecObjectTypes.Single().SpecAttributes.Any(x => x.LongName == this.booleanParameterType.ShortName));
         }
 
         [Test]

--- a/Requirements.Tests/ReqIF/ReqIFThingFactoryTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIFThingFactoryTestFixture.cs
@@ -165,10 +165,10 @@ namespace CDP4Requirements.Tests.ReqIF
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(1, factory.RelationGroupMap.Count);
-                Assert.AreEqual(1, factory.SpecRelationMap.Count);
-                Assert.AreEqual(2, factory.SpecificationMap.Count);
-                Assert.IsTrue(factory.SpecificationMap.All(x => x.Value.Requirement.Count == 1));
+                Assert.That(factory.RelationGroupMap, Has.Count.EqualTo(1));
+                Assert.That(factory.SpecRelationMap, Has.Count.EqualTo(1));
+                Assert.That(factory.SpecificationMap, Has.Count.EqualTo(2));
+                Assert.That(factory.SpecificationMap.All(x => x.Value.Requirement.Count == 1), Is.True);
             });
 
             var reqSpec1 = factory.SpecificationMap[this.specification1];
@@ -181,46 +181,65 @@ namespace CDP4Requirements.Tests.ReqIF
 
             Assert.Multiple(() =>
             {
-                Assert.AreSame(specificationRelationship.Source, reqSpec1);
-                Assert.AreSame(specificationRelationship.Target, reqSpec2);
-                Assert.AreSame(reqRelatinoship.Source, req1);
-                Assert.AreSame(reqRelatinoship.Target, req2);
+                Assert.That(reqSpec1, Is.SameAs(specificationRelationship.Source));
+                Assert.That(reqSpec2, Is.SameAs(specificationRelationship.Target));
+                Assert.That(req1, Is.SameAs(reqRelatinoship.Source));
+                Assert.That(req2, Is.SameAs(reqRelatinoship.Target));
 
-                Assert.IsNotEmpty(req1.Definition);
-                Assert.IsNotEmpty(req2.Definition);
+                Assert.That(req1.Definition, Is.Not.Empty);
+                Assert.That(req2.Definition, Is.Not.Empty);
 
-                Assert.AreEqual(reqSpec1.Name, this.specValue1.TheValue);
-                Assert.AreEqual(reqSpec2.Name, this.specValue2.TheValue);
+                Assert.That(this.specValue1.TheValue, Is.EqualTo(reqSpec1.Name));
+                Assert.That(this.specValue2.TheValue, Is.EqualTo(reqSpec2.Name));
             });
 
             var parameterValue = reqRelatinoship.ParameterValue.Single();
-            Assert.AreEqual(parameterValue.Value[0], this.specrelationValue.TheValue);
+            Assert.That(this.specrelationValue.TheValue, Is.EqualTo(parameterValue.Value[0]));
 
             //todo to complete
         }
 
         [Test]
-        public void VerifyThatXhtmlAttributeValuesAreConvertedToPlainText()
+        public void VerifyThatXhtmlRequirementTextIsImportedAsPlainText()
         {
-            // the plain-namespace form that the COMET exporter produces
-            Assert.AreEqual("Hello & welcome", ThingFactory.ConvertXhtmlToText("<div xmlns=\"http://www.w3.org/1999/xhtml\">Hello &amp; welcome</div>"));
+            // a DOORS/Capella-style rich-text (XHTML) requirement value must import as readable plain text, not raw markup:
+            // entities are decoded, inline tags removed, line-breaking elements become new lines and script/style are dropped
+            var xhtmlDatatype = new DatatypeDefinitionXHTML();
+            var reqXhtmlAttribute = new AttributeDefinitionXHTML { DatatypeDefinition = xhtmlDatatype };
+            this.specobjecttype.SpecAttributes.Add(reqXhtmlAttribute);
 
-            // a DOORS-style, prefixed and formatted value must import as readable text, not as raw markup
-            var doorsStyle = "<xhtml:div><xhtml:p>Line 1<xhtml:br/>Line 2</xhtml:p></xhtml:div>";
-            var converted = ThingFactory.ConvertXhtmlToText(doorsStyle);
+            this.specobject1.Values.Clear();
+            this.specobject1.Values.Add(new AttributeValueXHTML
+            {
+                AttributeDefinition = reqXhtmlAttribute,
+                TheValue = "<xhtml:div><xhtml:p>Hello &amp; <b>welcome</b><xhtml:br/>Line 2</xhtml:p><xhtml:style>.a{color:red}</xhtml:style><xhtml:script>alert('x');</xhtml:script></xhtml:div>"
+            });
+
+            var datatypeMap = new Dictionary<DatatypeDefinition, DatatypeDefinitionMap>
+            {
+                { this.stringDatadef, new DatatypeDefinitionMap(this.stringDatadef, this.pt, null) }
+            };
+
+            var spectypeMap = new Dictionary<SpecType, SpecTypeMap>
+            {
+                { this.specificationtype, new SpecTypeMap(this.specificationtype, null, new[] { this.specCategory }, new[] { new AttributeDefinitionMap(this.specAttribute, AttributeDefinitionMapKind.NAME) }) },
+                { this.specobjecttype, new SpecObjectTypeMap(this.specobjecttype, null, new[] { this.reqCateory }, new[] { new AttributeDefinitionMap(reqXhtmlAttribute, AttributeDefinitionMapKind.FIRST_DEFINITION) }, true) },
+                { this.specrelationtype, new SpecRelationTypeMap(this.specrelationtype, new[] { this.parameterRule }, new[] { this.specRelationCategory }, new[] { new AttributeDefinitionMap(this.specRelationAttribute, AttributeDefinitionMapKind.PARAMETER_VALUE) }, new[] { this.reqRule }) },
+                { this.relationgrouptype, new RelationGroupTypeMap(this.relationgrouptype, null, new[] { this.relationGroupCategory }, new[] { new AttributeDefinitionMap(this.relationgroupAttribute, AttributeDefinitionMapKind.NONE) }, new[] { this.specRule }) }
+            };
+
+            var factory = new ThingFactory(this.iteration, datatypeMap, spectypeMap, this.domain, this.reqIf.Lang);
+            factory.ComputeRequirementThings(this.reqIf);
+
+            var definitionContent = factory.SpecificationMap[this.specification1].Requirement.Single().Definition.Single().Content;
 
             Assert.Multiple(() =>
             {
-                Assert.IsFalse(converted.Contains("<"), "no raw markup remains");
-                StringAssert.Contains("Line 1", converted);
-                StringAssert.Contains("Line 2", converted);
-
-                // entities are decoded and inline tags removed
-                Assert.AreEqual("a <b> bold", ThingFactory.ConvertXhtmlToText("<div xmlns=\"http://www.w3.org/1999/xhtml\">a &lt;b&gt; <b>bold</b></div>"));
-
-                // null / empty are passed through unchanged
-                Assert.IsNull(ThingFactory.ConvertXhtmlToText(null));
-                Assert.AreEqual(string.Empty, ThingFactory.ConvertXhtmlToText(string.Empty));
+                Assert.That(definitionContent, Does.Contain("Hello & welcome"), "entities are decoded and inline tags removed");
+                Assert.That(definitionContent, Does.Contain("Line 2"), "line-breaking elements are honoured");
+                Assert.That(definitionContent, Does.Not.Contain("<"), "no raw markup remains");
+                Assert.That(definitionContent, Does.Not.Contain("alert"), "the script body is dropped");
+                Assert.That(definitionContent, Does.Not.Contain("color:red"), "the style body is dropped");
             });
         }
 

--- a/Requirements.Tests/ReqIF/ReqIFThingFactoryTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIFThingFactoryTestFixture.cs
@@ -163,10 +163,13 @@ namespace CDP4Requirements.Tests.ReqIF
             var factory = new ThingFactory(this.iteration, datatypeMap, spectypeMap, this.domain, this.reqIf.Lang);
             factory.ComputeRequirementThings(this.reqIf);
 
-            Assert.AreEqual(1, factory.RelationGroupMap.Count);
-            Assert.AreEqual(1, factory.SpecRelationMap.Count);
-            Assert.AreEqual(2, factory.SpecificationMap.Count);
-            Assert.IsTrue(factory.SpecificationMap.All(x => x.Value.Requirement.Count == 1));
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(1, factory.RelationGroupMap.Count);
+                Assert.AreEqual(1, factory.SpecRelationMap.Count);
+                Assert.AreEqual(2, factory.SpecificationMap.Count);
+                Assert.IsTrue(factory.SpecificationMap.All(x => x.Value.Requirement.Count == 1));
+            });
 
             var reqSpec1 = factory.SpecificationMap[this.specification1];
             var reqSpec2 = factory.SpecificationMap[this.specification2];
@@ -176,16 +179,19 @@ namespace CDP4Requirements.Tests.ReqIF
             var specificationRelationship = factory.RelationGroupMap.Single().Value;
             var reqRelatinoship = factory.SpecRelationMap.Single().Value;
 
-            Assert.AreSame(specificationRelationship.Source, reqSpec1);
-            Assert.AreSame(specificationRelationship.Target, reqSpec2);
-            Assert.AreSame(reqRelatinoship.Source, req1);
-            Assert.AreSame(reqRelatinoship.Target, req2);
+            Assert.Multiple(() =>
+            {
+                Assert.AreSame(specificationRelationship.Source, reqSpec1);
+                Assert.AreSame(specificationRelationship.Target, reqSpec2);
+                Assert.AreSame(reqRelatinoship.Source, req1);
+                Assert.AreSame(reqRelatinoship.Target, req2);
 
-            Assert.IsNotEmpty(req1.Definition);
-            Assert.IsNotEmpty(req2.Definition);
+                Assert.IsNotEmpty(req1.Definition);
+                Assert.IsNotEmpty(req2.Definition);
 
-            Assert.AreEqual(reqSpec1.Name, this.specValue1.TheValue);
-            Assert.AreEqual(reqSpec2.Name, this.specValue2.TheValue);
+                Assert.AreEqual(reqSpec1.Name, this.specValue1.TheValue);
+                Assert.AreEqual(reqSpec2.Name, this.specValue2.TheValue);
+            });
 
             var parameterValue = reqRelatinoship.ParameterValue.Single();
             Assert.AreEqual(parameterValue.Value[0], this.specrelationValue.TheValue);
@@ -203,16 +209,19 @@ namespace CDP4Requirements.Tests.ReqIF
             var doorsStyle = "<xhtml:div><xhtml:p>Line 1<xhtml:br/>Line 2</xhtml:p></xhtml:div>";
             var converted = ThingFactory.ConvertXhtmlToText(doorsStyle);
 
-            Assert.IsFalse(converted.Contains("<"), "no raw markup remains");
-            StringAssert.Contains("Line 1", converted);
-            StringAssert.Contains("Line 2", converted);
+            Assert.Multiple(() =>
+            {
+                Assert.IsFalse(converted.Contains("<"), "no raw markup remains");
+                StringAssert.Contains("Line 1", converted);
+                StringAssert.Contains("Line 2", converted);
 
-            // entities are decoded and inline tags removed
-            Assert.AreEqual("a <b> bold", ThingFactory.ConvertXhtmlToText("<div xmlns=\"http://www.w3.org/1999/xhtml\">a &lt;b&gt; <b>bold</b></div>"));
+                // entities are decoded and inline tags removed
+                Assert.AreEqual("a <b> bold", ThingFactory.ConvertXhtmlToText("<div xmlns=\"http://www.w3.org/1999/xhtml\">a &lt;b&gt; <b>bold</b></div>"));
 
-            // null / empty are passed through unchanged
-            Assert.IsNull(ThingFactory.ConvertXhtmlToText(null));
-            Assert.AreEqual(string.Empty, ThingFactory.ConvertXhtmlToText(string.Empty));
+                // null / empty are passed through unchanged
+                Assert.IsNull(ThingFactory.ConvertXhtmlToText(null));
+                Assert.AreEqual(string.Empty, ThingFactory.ConvertXhtmlToText(string.Empty));
+            });
         }
 
         private void SetupThings()

--- a/Requirements.Tests/ReqIF/ReqIFThingFactoryTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIFThingFactoryTestFixture.cs
@@ -193,6 +193,28 @@ namespace CDP4Requirements.Tests.ReqIF
             //todo to complete
         }
 
+        [Test]
+        public void VerifyThatXhtmlAttributeValuesAreConvertedToPlainText()
+        {
+            // the plain-namespace form that the COMET exporter produces
+            Assert.AreEqual("Hello & welcome", ThingFactory.ConvertXhtmlToText("<div xmlns=\"http://www.w3.org/1999/xhtml\">Hello &amp; welcome</div>"));
+
+            // a DOORS-style, prefixed and formatted value must import as readable text, not as raw markup
+            var doorsStyle = "<xhtml:div><xhtml:p>Line 1<xhtml:br/>Line 2</xhtml:p></xhtml:div>";
+            var converted = ThingFactory.ConvertXhtmlToText(doorsStyle);
+
+            Assert.IsFalse(converted.Contains("<"), "no raw markup remains");
+            StringAssert.Contains("Line 1", converted);
+            StringAssert.Contains("Line 2", converted);
+
+            // entities are decoded and inline tags removed
+            Assert.AreEqual("a <b> bold", ThingFactory.ConvertXhtmlToText("<div xmlns=\"http://www.w3.org/1999/xhtml\">a &lt;b&gt; <b>bold</b></div>"));
+
+            // null / empty are passed through unchanged
+            Assert.IsNull(ThingFactory.ConvertXhtmlToText(null));
+            Assert.AreEqual(string.Empty, ThingFactory.ConvertXhtmlToText(string.Empty));
+        }
+
         private void SetupThings()
         {
             this.sitedir = new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri);

--- a/Requirements.Tests/ReqIF/ReqIfImportDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIfImportDialogViewModelTestFixture.cs
@@ -179,7 +179,7 @@ namespace CDP4Requirements.Tests.ReqIF
         public async Task VerifyThatCancelCommandWorks()
         {
             await this.dialog.CancelCommand.Execute();
-            Assert.IsFalse(this.dialog.DialogResult.Result.Value);
+            Assert.That(this.dialog.DialogResult.Result.Value, Is.False);
         }
 
         [Test]
@@ -187,35 +187,35 @@ namespace CDP4Requirements.Tests.ReqIF
         {
             await this.dialog.BrowseCommand.Execute();
             this.fileDialogService.Verify(x => x.GetOpenFileDialog(true, true, false, It.Is<string>(filter => filter.Contains(".reqifz") && filter.Contains(".zip")), It.IsAny<string>(), It.IsAny<string>(), 1), Times.Once);
-            Assert.IsNotNull(this.dialog.Path);
+            Assert.That(this.dialog.Path, Is.Not.Null);
         }
 
         [Test]
         public async Task VerifyThatExecuteOkWorks()
         {
-            Assert.IsFalse(this.dialog.CanExecuteImport);
+            Assert.That(this.dialog.CanExecuteImport, Is.False);
             this.dialog.Path = this.path;
             this.dialog.SelectedIteration = this.dialog.Iterations.First();
 
-            Assert.IsTrue(this.dialog.CanExecuteImport);
+            Assert.That(this.dialog.CanExecuteImport, Is.True);
             await this.dialog.OkCommand.Execute();
             this.reqIfSerialiser.Verify(x => x.Deserialize(It.IsAny<string>(), It.IsAny<bool>(), null), Times.Once);
             this.pluginSettingService.Verify(x => x.Read<RequirementsModuleSettings>(true, It.IsAny<JsonConverter[]>()), Times.Once);
             var result = this.dialog.DialogResult as ReqIfImportResult;
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(result);
-                Assert.IsTrue(result?.Result.Value);
-                Assert.AreSame(this.settings.SavedConfigurations[0], result.MappingConfiguration);
-                Assert.IsNotNull(result.Iteration);
-                Assert.IsNotNull(result.ReqIfObject);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result?.Result.Value, Is.True);
+                Assert.That(result.MappingConfiguration, Is.SameAs(this.settings.SavedConfigurations[0]));
+                Assert.That(result.Iteration, Is.Not.Null);
+                Assert.That(result.ReqIfObject, Is.Not.Null);
             });
         }
 
         [Test]
         public async Task VerifyThatSavedConfigurationArePickedUpCorrectly()
         {
-            Assert.IsFalse(this.dialog.CanExecuteImport);
+            Assert.That(this.dialog.CanExecuteImport, Is.False);
             this.dialog.Path = this.path;
             this.dialog.SelectedIteration = this.dialog.Iterations.First();
 
@@ -223,54 +223,54 @@ namespace CDP4Requirements.Tests.ReqIF
             this.dialog.SelectedMappingConfiguration = this.dialog.AvailableMappingConfiguration.FirstOrDefault(x => x.Name == ReqIfImportDialogViewModel.NoConfigurationText);
             Assert.Multiple(() =>
             {
-                Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == ReqIfImportDialogViewModel.NoConfigurationText);
+                Assert.That(this.dialog.SelectedMappingConfiguration.Name == ReqIfImportDialogViewModel.NoConfigurationText, Is.True);
 
-                Assert.IsTrue(this.dialog.CanExecuteImport);
+                Assert.That(this.dialog.CanExecuteImport, Is.True);
             });
             await this.dialog.OkCommand.Execute();
             var resultNoConfiguration = this.dialog.DialogResult as ReqIfImportResult;
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(resultNoConfiguration);
-                Assert.IsTrue(resultNoConfiguration?.Result.Value);
-                Assert.IsNull(resultNoConfiguration.MappingConfiguration);
+                Assert.That(resultNoConfiguration, Is.Not.Null);
+                Assert.That(resultNoConfiguration?.Result.Value, Is.True);
+                Assert.That(resultNoConfiguration.MappingConfiguration, Is.Null);
             });
 
             //With AUTO selection of the mapping configuration
             this.dialog.SelectedMappingConfiguration = this.dialog.AvailableMappingConfiguration.FirstOrDefault(x => x.Name == ReqIfImportDialogViewModel.AutoConfigurationText);
             Assert.Multiple(() =>
             {
-                Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == ReqIfImportDialogViewModel.AutoConfigurationText);
+                Assert.That(this.dialog.SelectedMappingConfiguration.Name == ReqIfImportDialogViewModel.AutoConfigurationText, Is.True);
 
-                Assert.IsTrue(this.dialog.CanExecuteImport);
+                Assert.That(this.dialog.CanExecuteImport, Is.True);
             });
             await this.dialog.OkCommand.Execute();
 
-            Assert.IsNotNull(this.dialog.SelectedMappingConfiguration);
+            Assert.That(this.dialog.SelectedMappingConfiguration, Is.Not.Null);
             var resultAutoSelectedConfiguration = this.dialog.DialogResult as ReqIfImportResult;
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(resultAutoSelectedConfiguration);
-                Assert.IsTrue(resultAutoSelectedConfiguration?.Result.Value);
-                Assert.AreSame(this.settings.SavedConfigurations[0], resultAutoSelectedConfiguration.MappingConfiguration);
+                Assert.That(resultAutoSelectedConfiguration, Is.Not.Null);
+                Assert.That(resultAutoSelectedConfiguration?.Result.Value, Is.True);
+                Assert.That(resultAutoSelectedConfiguration.MappingConfiguration, Is.SameAs(this.settings.SavedConfigurations[0]));
             });
 
             //With explicite selection
             this.dialog.SelectedMappingConfiguration = this.dialog.AvailableMappingConfiguration.Last();
             Assert.Multiple(() =>
             {
-                Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == this.settings.SavedConfigurations.Last().Name);
+                Assert.That(this.dialog.SelectedMappingConfiguration.Name == this.settings.SavedConfigurations.Last().Name, Is.True);
 
-                Assert.IsTrue(this.dialog.CanExecuteImport);
+                Assert.That(this.dialog.CanExecuteImport, Is.True);
             });
             await this.dialog.OkCommand.Execute();
-            Assert.IsNotNull(this.dialog.SelectedMappingConfiguration);
+            Assert.That(this.dialog.SelectedMappingConfiguration, Is.Not.Null);
             var result = this.dialog.DialogResult as ReqIfImportResult;
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(result);
-                Assert.IsTrue(result?.Result.Value);
-                Assert.AreSame(this.settings.SavedConfigurations[0], result.MappingConfiguration);
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result?.Result.Value, Is.True);
+                Assert.That(result.MappingConfiguration, Is.SameAs(this.settings.SavedConfigurations[0]));
             });
 
             //Verifications on Mocks

--- a/Requirements.Tests/ReqIF/ReqIfImportDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIfImportDialogViewModelTestFixture.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReqIfImportDialogViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
 //
@@ -186,7 +186,7 @@ namespace CDP4Requirements.Tests.ReqIF
         public async Task VerifyBrowseCommand()
         {
             await this.dialog.BrowseCommand.Execute();
-            this.fileDialogService.Verify(x => x.GetOpenFileDialog(true, true, false, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), 1), Times.Once);
+            this.fileDialogService.Verify(x => x.GetOpenFileDialog(true, true, false, It.Is<string>(filter => filter.Contains(".reqifz") && filter.Contains(".zip")), It.IsAny<string>(), It.IsAny<string>(), 1), Times.Once);
             Assert.IsNotNull(this.dialog.Path);
         }
 

--- a/Requirements.Tests/ReqIF/ReqIfImportDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/ReqIF/ReqIfImportDialogViewModelTestFixture.cs
@@ -202,11 +202,14 @@ namespace CDP4Requirements.Tests.ReqIF
             this.reqIfSerialiser.Verify(x => x.Deserialize(It.IsAny<string>(), It.IsAny<bool>(), null), Times.Once);
             this.pluginSettingService.Verify(x => x.Read<RequirementsModuleSettings>(true, It.IsAny<JsonConverter[]>()), Times.Once);
             var result = this.dialog.DialogResult as ReqIfImportResult;
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result?.Result.Value);
-            Assert.AreSame(this.settings.SavedConfigurations[0], result.MappingConfiguration);
-            Assert.IsNotNull(result.Iteration);
-            Assert.IsNotNull(result.ReqIfObject);
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result?.Result.Value);
+                Assert.AreSame(this.settings.SavedConfigurations[0], result.MappingConfiguration);
+                Assert.IsNotNull(result.Iteration);
+                Assert.IsNotNull(result.ReqIfObject);
+            });
         }
 
         [Test]
@@ -218,39 +221,57 @@ namespace CDP4Requirements.Tests.ReqIF
 
             // Without Any Configuration
             this.dialog.SelectedMappingConfiguration = this.dialog.AvailableMappingConfiguration.FirstOrDefault(x => x.Name == ReqIfImportDialogViewModel.NoConfigurationText);
-            Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == ReqIfImportDialogViewModel.NoConfigurationText);
+            Assert.Multiple(() =>
+            {
+                Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == ReqIfImportDialogViewModel.NoConfigurationText);
 
-            Assert.IsTrue(this.dialog.CanExecuteImport);
+                Assert.IsTrue(this.dialog.CanExecuteImport);
+            });
             await this.dialog.OkCommand.Execute();
             var resultNoConfiguration = this.dialog.DialogResult as ReqIfImportResult;
-            Assert.IsNotNull(resultNoConfiguration);
-            Assert.IsTrue(resultNoConfiguration?.Result.Value);
-            Assert.IsNull(resultNoConfiguration.MappingConfiguration);
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(resultNoConfiguration);
+                Assert.IsTrue(resultNoConfiguration?.Result.Value);
+                Assert.IsNull(resultNoConfiguration.MappingConfiguration);
+            });
 
             //With AUTO selection of the mapping configuration
             this.dialog.SelectedMappingConfiguration = this.dialog.AvailableMappingConfiguration.FirstOrDefault(x => x.Name == ReqIfImportDialogViewModel.AutoConfigurationText);
-            Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == ReqIfImportDialogViewModel.AutoConfigurationText);
+            Assert.Multiple(() =>
+            {
+                Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == ReqIfImportDialogViewModel.AutoConfigurationText);
 
-            Assert.IsTrue(this.dialog.CanExecuteImport);
+                Assert.IsTrue(this.dialog.CanExecuteImport);
+            });
             await this.dialog.OkCommand.Execute();
 
             Assert.IsNotNull(this.dialog.SelectedMappingConfiguration);
             var resultAutoSelectedConfiguration = this.dialog.DialogResult as ReqIfImportResult;
-            Assert.IsNotNull(resultAutoSelectedConfiguration);
-            Assert.IsTrue(resultAutoSelectedConfiguration?.Result.Value);
-            Assert.AreSame(this.settings.SavedConfigurations[0], resultAutoSelectedConfiguration.MappingConfiguration);
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(resultAutoSelectedConfiguration);
+                Assert.IsTrue(resultAutoSelectedConfiguration?.Result.Value);
+                Assert.AreSame(this.settings.SavedConfigurations[0], resultAutoSelectedConfiguration.MappingConfiguration);
+            });
 
             //With explicite selection
             this.dialog.SelectedMappingConfiguration = this.dialog.AvailableMappingConfiguration.Last();
-            Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == this.settings.SavedConfigurations.Last().Name);
+            Assert.Multiple(() =>
+            {
+                Assert.IsTrue(this.dialog.SelectedMappingConfiguration.Name == this.settings.SavedConfigurations.Last().Name);
 
-            Assert.IsTrue(this.dialog.CanExecuteImport);
+                Assert.IsTrue(this.dialog.CanExecuteImport);
+            });
             await this.dialog.OkCommand.Execute();
             Assert.IsNotNull(this.dialog.SelectedMappingConfiguration);
             var result = this.dialog.DialogResult as ReqIfImportResult;
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result?.Result.Value);
-            Assert.AreSame(this.settings.SavedConfigurations[0], result.MappingConfiguration);
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result?.Result.Value);
+                Assert.AreSame(this.settings.SavedConfigurations[0], result.MappingConfiguration);
+            });
 
             //Verifications on Mocks
 

--- a/Requirements/ReqIFDal/ReqIFBuilder.cs
+++ b/Requirements/ReqIFDal/ReqIFBuilder.cs
@@ -180,10 +180,10 @@ namespace CDP4Requirements.ReqIFDal
         /// of the <paramref name="iteration"/> are exported.
         /// </param>
         /// <param name="profile">
-        /// The <see cref="ReqIfExportProfile"/> to target. Defaults to <see cref="ReqIfExportProfile.DoorsCapella"/>.
+        /// The <see cref="ReqIfExportProfile"/> to target. Defaults to <see cref="ReqIfExportProfile.Omg"/>.
         /// </param>
         /// <returns>The <see cref="ReqIF"/> instance</returns>
-        public ReqIF BuildReqIF(ISession session, Iteration iteration, bool includeDeprecated = false, IEnumerable<RequirementsSpecification> requirementsSpecifications = null, ReqIfExportProfile profile = ReqIfExportProfile.DoorsCapella)
+        public ReqIF BuildReqIF(ISession session, Iteration iteration, bool includeDeprecated = false, IEnumerable<RequirementsSpecification> requirementsSpecifications = null, ReqIfExportProfile profile = ReqIfExportProfile.Omg)
         {
             this.currentSession = session ?? throw new ArgumentNullException(nameof(session));
             var exportedIteration = iteration ?? throw new ArgumentNullException(nameof(iteration));

--- a/Requirements/ReqIFDal/ReqIFBuilder.cs
+++ b/Requirements/ReqIFDal/ReqIFBuilder.cs
@@ -723,45 +723,5 @@ namespace CDP4Requirements.ReqIFDal
         {
             //TODO
         }
-
-        /// <summary>
-        /// Compares two sets of <see cref="ParameterizedCategoryRule"/>s for equality, ignoring order, so that
-        /// requirements can be grouped by their applied rule-set.
-        /// </summary>
-        private sealed class RuleSetEqualityComparer : IEqualityComparer<ParameterizedCategoryRule[]>
-        {
-            /// <summary>
-            /// Determines whether two rule-sets contain the same rules, regardless of order.
-            /// </summary>
-            /// <param name="x">The first rule-set</param>
-            /// <param name="y">The second rule-set</param>
-            /// <returns>True if both rule-sets contain the same rules</returns>
-            public bool Equals(ParameterizedCategoryRule[] x, ParameterizedCategoryRule[] y)
-            {
-                if (x == null || y == null)
-                {
-                    return x == y;
-                }
-
-                return x.Length == y.Length && !x.Except(y).Any();
-            }
-
-            /// <summary>
-            /// Returns an order-independent hash-code for a rule-set.
-            /// </summary>
-            /// <param name="obj">The rule-set</param>
-            /// <returns>The hash-code</returns>
-            public int GetHashCode(ParameterizedCategoryRule[] obj)
-            {
-                var hash = 0;
-
-                foreach (var rule in obj)
-                {
-                    hash ^= rule.Iid.GetHashCode();
-                }
-
-                return hash;
-            }
-        }
     }
 }

--- a/Requirements/ReqIFDal/ReqIFBuilder.cs
+++ b/Requirements/ReqIFDal/ReqIFBuilder.cs
@@ -398,14 +398,34 @@ namespace CDP4Requirements.ReqIFDal
         /// </remarks>
         private void InstantiateRequirementType()
         {
+            var requirementTypes = new Dictionary<string, SpecObjectType>();
+
             foreach (var requirement in this.toBeExportedRequirements)
             {
-                // TODO: Next step in GH IME #255. Currently a short term fix. The intent of reuse of spec type with use of applied rules is a bit unintuitive and convoluted without clear reasoning. Needs to be completely looked over.
-                // current solution will create a spec type per requirement and not reuse them (which leads to errors due to no use of rules/different SPVs)
                 var appliedRules = this.toBeExportedParameterizedCategoryRules.Where(r => requirement.IsMemberOfCategory(r.Category)).ToArray();
+
+                var parameterTypeSignature =
+                    appliedRules.SelectMany(r => r.ParameterType)
+                        .Concat(requirement.ParameterValue.Select(pv => pv.ParameterType))
+                        .Where(pt => pt != null)
+                        .Select(pt => pt.Iid)
+                        .Distinct()
+                        .OrderBy(iid => iid);
+
+                var signature =
+                    string.Join(",", appliedRules.Select(r => r.Iid).OrderBy(iid => iid))
+                    + "|"
+                    + string.Join(",", parameterTypeSignature);
+
+                if (requirementTypes.TryGetValue(signature, out var existingReqType))
+                {
+                    this.specType.Add(requirement, existingReqType);
+                    continue;
+                }
 
                 var reqType = this.mapper.ToReqIfSpecObjectType(requirement, appliedRules, this.parameterTypeMap);
 
+                requirementTypes.Add(signature, reqType);
                 this.specTypeMap.Add(reqType, appliedRules);
                 this.specType.Add(requirement, reqType);
             }

--- a/Requirements/ReqIFDal/ReqIFBuilder.cs
+++ b/Requirements/ReqIFDal/ReqIFBuilder.cs
@@ -175,8 +175,15 @@ namespace CDP4Requirements.ReqIFDal
         /// <param name="session">The <see cref="ISession"/> containing the <see cref="Iteration"/></param>
         /// <param name="iteration">The <see cref="Iteration"/></param>
         /// <param name="includeDeprecated">Indicates if Deprecated items should be included or not</param>
+        /// <param name="requirementsSpecifications">
+        /// The <see cref="RequirementsSpecification"/>s to export. When null, all the <see cref="RequirementsSpecification"/>s
+        /// of the <paramref name="iteration"/> are exported.
+        /// </param>
+        /// <param name="profile">
+        /// The <see cref="ReqIfExportProfile"/> to target. Defaults to <see cref="ReqIfExportProfile.DoorsCapella"/>.
+        /// </param>
         /// <returns>The <see cref="ReqIF"/> instance</returns>
-        public ReqIF BuildReqIF(ISession session, Iteration iteration, bool includeDeprecated = false)
+        public ReqIF BuildReqIF(ISession session, Iteration iteration, bool includeDeprecated = false, IEnumerable<RequirementsSpecification> requirementsSpecifications = null, ReqIfExportProfile profile = ReqIfExportProfile.DoorsCapella)
         {
             this.currentSession = session ?? throw new ArgumentNullException(nameof(session));
             var exportedIteration = iteration ?? throw new ArgumentNullException(nameof(iteration));
@@ -186,7 +193,9 @@ namespace CDP4Requirements.ReqIFDal
                 throw new InvalidOperationException("The iteration is not contained in the session's database.");
             }
 
-            this.SetIterationProperties(exportedIteration, includeDeprecated);
+            this.mapper.Profile = profile;
+
+            this.SetIterationProperties(exportedIteration, includeDeprecated, requirementsSpecifications);
 
             this.reqIFBuilt = new ReqIF { Lang = this.language };
             this.SetHeader();
@@ -204,21 +213,29 @@ namespace CDP4Requirements.ReqIFDal
         /// </summary>
         /// <param name="toBeExportedIteration">The <see cref="Iteration"/> to be Exported</param>
         /// <param name="includeDeprecated">Indicates if Deprecated items should be included or not</param>
-        private void SetIterationProperties(Iteration toBeExportedIteration, bool includeDeprecated)
+        /// <param name="requirementsSpecifications">
+        /// The <see cref="RequirementsSpecification"/>s to export. When null, all the <see cref="RequirementsSpecification"/>s
+        /// of the <paramref name="toBeExportedIteration"/> are exported.
+        /// </param>
+        private void SetIterationProperties(Iteration toBeExportedIteration, bool includeDeprecated, IEnumerable<RequirementsSpecification> requirementsSpecifications)
         {
             this.toBeExportedIteration = toBeExportedIteration;
 
             this.toBeExportedEngineeringModel = (EngineeringModel)toBeExportedIteration.Container;
 
-            this.toBeExportedParameterizedCategoryRules = 
+            this.toBeExportedParameterizedCategoryRules =
                 this.toBeExportedEngineeringModel.RequiredRdls
                     .SelectMany(rdl => rdl.Rule)
                     .OfType<ParameterizedCategoryRule>()
                     .ToArray();
 
+            var selectedRequirementsSpecifications = requirementsSpecifications?.ToArray();
+
             this.toBeExportedRequirementsSpecifications =
                 toBeExportedIteration.RequirementsSpecification
-                    .Where(x => includeDeprecated || !x.IsDeprecated).ToArray();
+                    .Where(x => includeDeprecated || !x.IsDeprecated)
+                    .Where(x => selectedRequirementsSpecifications == null || selectedRequirementsSpecifications.Contains(x))
+                    .ToArray();
 
             this.toBeExportedRequirements =
                 this.toBeExportedRequirementsSpecifications.SelectMany(x => x.Requirement)
@@ -281,6 +298,11 @@ namespace CDP4Requirements.ReqIFDal
             // add extra requirement datatype
             content.DataTypes.Add(this.mapper.TextDatatypeDefinition);
             content.DataTypes.Add(this.mapper.BooleanDatatypeDefinition);
+
+            if (this.mapper.ExportXhtmlText)
+            {
+                content.DataTypes.Add(this.mapper.XhtmlDatatypeDefinition);
+            }
 
             content.Specifications.AddRange(this.requirementSpecificationsMap.Values);
             content.SpecObjects.AddRange(this.requirementMap.Values);
@@ -398,36 +420,32 @@ namespace CDP4Requirements.ReqIFDal
         /// </remarks>
         private void InstantiateRequirementType()
         {
-            var requirementTypes = new Dictionary<string, SpecObjectType>();
+            // group the requirements by their set of applied rules; all requirements that share the same rule-set get
+            // a single SpecObjectType whose attributes are the union of the parameters used across the group. This
+            // avoids a separate type per parameter combination, matching what ReqIF tools such as DOORS and Capella expect.
+            var groupedByRuleSet = this.toBeExportedRequirements
+                .GroupBy(
+                    requirement => this.toBeExportedParameterizedCategoryRules.Where(r => requirement.IsMemberOfCategory(r.Category)).OrderBy(r => r.Iid).ToArray(),
+                    new RuleSetEqualityComparer());
 
-            foreach (var requirement in this.toBeExportedRequirements)
+            foreach (var group in groupedByRuleSet)
             {
-                var appliedRules = this.toBeExportedParameterizedCategoryRules.Where(r => requirement.IsMemberOfCategory(r.Category)).ToArray();
+                var appliedRules = group.Key;
 
-                var parameterTypeSignature =
-                    appliedRules.SelectMany(r => r.ParameterType)
-                        .Concat(requirement.ParameterValue.Select(pv => pv.ParameterType))
-                        .Where(pt => pt != null)
-                        .Select(pt => pt.Iid)
-                        .Distinct()
-                        .OrderBy(iid => iid);
+                var unionParameterTypes = appliedRules.SelectMany(r => r.ParameterType)
+                    .Concat(group.SelectMany(requirement => requirement.ParameterValue.Select(pv => pv.ParameterType)))
+                    .Where(pt => pt != null)
+                    .Distinct()
+                    .ToArray();
 
-                var signature =
-                    string.Join(",", appliedRules.Select(r => r.Iid).OrderBy(iid => iid))
-                    + "|"
-                    + string.Join(",", parameterTypeSignature);
+                var reqType = this.mapper.ToReqIfSpecObjectType(appliedRules, unionParameterTypes, this.parameterTypeMap);
 
-                if (requirementTypes.TryGetValue(signature, out var existingReqType))
-                {
-                    this.specType.Add(requirement, existingReqType);
-                    continue;
-                }
-
-                var reqType = this.mapper.ToReqIfSpecObjectType(requirement, appliedRules, this.parameterTypeMap);
-
-                requirementTypes.Add(signature, reqType);
                 this.specTypeMap.Add(reqType, appliedRules);
-                this.specType.Add(requirement, reqType);
+
+                foreach (var requirement in group)
+                {
+                    this.specType.Add(requirement, reqType);
+                }
             }
         }
 
@@ -704,6 +722,46 @@ namespace CDP4Requirements.ReqIFDal
         private void BuildToolExtension()
         {
             //TODO
+        }
+
+        /// <summary>
+        /// Compares two sets of <see cref="ParameterizedCategoryRule"/>s for equality, ignoring order, so that
+        /// requirements can be grouped by their applied rule-set.
+        /// </summary>
+        private sealed class RuleSetEqualityComparer : IEqualityComparer<ParameterizedCategoryRule[]>
+        {
+            /// <summary>
+            /// Determines whether two rule-sets contain the same rules, regardless of order.
+            /// </summary>
+            /// <param name="x">The first rule-set</param>
+            /// <param name="y">The second rule-set</param>
+            /// <returns>True if both rule-sets contain the same rules</returns>
+            public bool Equals(ParameterizedCategoryRule[] x, ParameterizedCategoryRule[] y)
+            {
+                if (x == null || y == null)
+                {
+                    return x == y;
+                }
+
+                return x.Length == y.Length && !x.Except(y).Any();
+            }
+
+            /// <summary>
+            /// Returns an order-independent hash-code for a rule-set.
+            /// </summary>
+            /// <param name="obj">The rule-set</param>
+            /// <returns>The hash-code</returns>
+            public int GetHashCode(ParameterizedCategoryRule[] obj)
+            {
+                var hash = 0;
+
+                foreach (var rule in obj)
+                {
+                    hash ^= rule.Iid.GetHashCode();
+                }
+
+                return hash;
+            }
         }
     }
 }

--- a/Requirements/ReqIFDal/ReqIfExportProfile.cs
+++ b/Requirements/ReqIFDal/ReqIfExportProfile.cs
@@ -1,0 +1,46 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ReqIfExportProfile.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Requirements.ReqIFDal
+{
+    /// <summary>
+    /// The interoperability profile that a ReqIF export targets. Both profiles produce valid OMG ReqIF; they differ
+    /// only in the conventions that ease consumption by other tools.
+    /// </summary>
+    public enum ReqIfExportProfile
+    {
+        /// <summary>
+        /// The prostep ivip / DOORS / Capella interoperability profile: the requirement text is additionally exported
+        /// as rich-text (XHTML) and the identity attributes use the reserved <c>ReqIF.*</c> names so that those tools
+        /// map them to their built-in fields automatically.
+        /// </summary>
+        DoorsCapella,
+
+        /// <summary>
+        /// Plain OMG ReqIF with the COMET-native attribute names and no rich-text (XHTML) attribute.
+        /// </summary>
+        Omg
+    }
+}

--- a/Requirements/ReqIFDal/RuleSetEqualityComparer.cs
+++ b/Requirements/ReqIFDal/RuleSetEqualityComparer.cs
@@ -1,0 +1,72 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RuleSetEqualityComparer.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Requirements.ReqIFDal
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Compares two sets of <see cref="ParameterizedCategoryRule"/>s for equality, ignoring order, so that
+    /// requirements can be grouped by their applied rule-set.
+    /// </summary>
+    internal sealed class RuleSetEqualityComparer : IEqualityComparer<ParameterizedCategoryRule[]>
+    {
+        /// <summary>
+        /// Determines whether two rule-sets contain the same rules, regardless of order.
+        /// </summary>
+        /// <param name="x">The first rule-set</param>
+        /// <param name="y">The second rule-set</param>
+        /// <returns>True if both rule-sets contain the same rules</returns>
+        public bool Equals(ParameterizedCategoryRule[] x, ParameterizedCategoryRule[] y)
+        {
+            if (x == null || y == null)
+            {
+                return x == y;
+            }
+
+            return x.Length == y.Length && !x.Except(y).Any();
+        }
+
+        /// <summary>
+        /// Returns an order-independent hash-code for a rule-set.
+        /// </summary>
+        /// <param name="obj">The rule-set</param>
+        /// <returns>The hash-code</returns>
+        public int GetHashCode(ParameterizedCategoryRule[] obj)
+        {
+            var hash = 0;
+
+            foreach (var rule in obj)
+            {
+                hash ^= rule.Iid.GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+}

--- a/Requirements/ReqIFDal/ThingFactory.cs
+++ b/Requirements/ReqIFDal/ThingFactory.cs
@@ -1,27 +1,27 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ThingFactory.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2021 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of CDP4-IME Community Edition.
-//    The CDP4-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
-//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Affero General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or any later version.
 //
-//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //    GNU Affero General Public License for more details.
 //
 //    You should have received a copy of the GNU Affero General Public License
-//    along with this program. If not, see <http://www.gnu.org/licenses/>.
+//    along with this program. If not, see http://www.gnu.org/licenses/.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4Requirements.ReqIFDal
 {
@@ -30,6 +30,8 @@ namespace CDP4Requirements.ReqIFDal
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Net;
+    using System.Text.RegularExpressions;
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
@@ -641,6 +643,13 @@ namespace CDP4Requirements.ReqIFDal
         /// <returns>The string value</returns>
         private string GetAttributeValue(AttributeValue value)
         {
+            // an XHTML (rich-text) value carries its content as XHTML markup; convert it to readable plain text
+            // instead of importing the raw &lt;div&gt;...&lt;/div&gt; markup as-is.
+            if (value is AttributeValueXHTML xhtmlValue)
+            {
+                return ConvertXhtmlToText(xhtmlValue.TheValue);
+            }
+
             var valueType = value.GetType();
 
             var valueProperty = valueType.GetProperty("TheValue");
@@ -679,6 +688,32 @@ namespace CDP4Requirements.ReqIFDal
 
             theValue = string.Join(" | ", stringList);
             return theValue;
+        }
+
+        /// <summary>
+        /// Converts an XHTML (rich-text) attribute value to readable plain text. Line-breaking elements become new
+        /// lines, the remaining tags are removed and the XML/HTML entities are decoded. This keeps the textual content
+        /// of DOORS/Capella (and other) XHTML attributes instead of importing the raw markup.
+        /// </summary>
+        /// <param name="xhtml">The XHTML markup</param>
+        /// <returns>The plain-text representation</returns>
+        internal static string ConvertXhtmlToText(string xhtml)
+        {
+            if (string.IsNullOrEmpty(xhtml))
+            {
+                return xhtml;
+            }
+
+            // turn line-breaking elements (with or without an xhtml prefix, opening or closing) into new lines
+            var text = Regex.Replace(xhtml, @"<\s*/?\s*(?:[a-zA-Z]+:)?(?:br|p|div|li|tr)(?:\s[^>]*)?/?\s*>", "\n", RegexOptions.IgnoreCase);
+
+            // remove any remaining tags
+            text = Regex.Replace(text, "<[^>]+>", string.Empty);
+
+            // decode XML/HTML entities such as &amp; and &lt;
+            text = WebUtility.HtmlDecode(text);
+
+            return text.Trim();
         }
     }
 }

--- a/Requirements/ReqIFDal/ThingFactory.cs
+++ b/Requirements/ReqIFDal/ThingFactory.cs
@@ -691,24 +691,43 @@ namespace CDP4Requirements.ReqIFDal
         }
 
         /// <summary>
-        /// Converts an XHTML (rich-text) attribute value to readable plain text. Line-breaking elements become new
-        /// lines, the remaining tags are removed and the XML/HTML entities are decoded. This keeps the textual content
-        /// of DOORS/Capella (and other) XHTML attributes instead of importing the raw markup.
+        /// Matches <c>script</c> and <c>style</c> elements together with their content so their body is not leaked into the text
+        /// </summary>
+        private static readonly Regex ScriptOrStyleElementRegex = new Regex(@"<\s*(?:[a-zA-Z]+:)?(script|style)\b[^>]*>.*?<\s*/\s*(?:[a-zA-Z]+:)?\1\s*>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Matches the line-breaking elements (with or without an xhtml prefix, opening or closing) that should become new lines
+        /// </summary>
+        private static readonly Regex LineBreakingElementRegex = new Regex(@"<\s*/?\s*(?:[a-zA-Z]+:)?(?:br|p|div|li|tr)(?:\s[^>]*)?/?\s*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Matches any remaining markup tag
+        /// </summary>
+        private static readonly Regex RemainingTagRegex = new Regex("<[^>]+>", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Converts an XHTML (rich-text) attribute value to readable plain text. <c>script</c>/<c>style</c> elements are
+        /// dropped with their content, line-breaking elements become new lines, the remaining tags are removed and the
+        /// XML/HTML entities are decoded. This keeps the textual content of DOORS/Capella (and other) XHTML attributes
+        /// instead of importing the raw markup.
         /// </summary>
         /// <param name="xhtml">The XHTML markup</param>
         /// <returns>The plain-text representation</returns>
-        internal static string ConvertXhtmlToText(string xhtml)
+        private static string ConvertXhtmlToText(string xhtml)
         {
             if (string.IsNullOrEmpty(xhtml))
             {
                 return xhtml;
             }
 
-            // turn line-breaking elements (with or without an xhtml prefix, opening or closing) into new lines
-            var text = Regex.Replace(xhtml, @"<\s*/?\s*(?:[a-zA-Z]+:)?(?:br|p|div|li|tr)(?:\s[^>]*)?/?\s*>", "\n", RegexOptions.IgnoreCase);
+            // drop script/style elements together with their content
+            var text = ScriptOrStyleElementRegex.Replace(xhtml, string.Empty);
+
+            // turn line-breaking elements into new lines
+            text = LineBreakingElementRegex.Replace(text, "\n");
 
             // remove any remaining tags
-            text = Regex.Replace(text, "<[^>]+>", string.Empty);
+            text = RemainingTagRegex.Replace(text, string.Empty);
 
             // decode XML/HTML entities such as &amp; and &lt;
             text = WebUtility.HtmlDecode(text);

--- a/Requirements/ReqIFDal/ThingToReqIfMapper.cs
+++ b/Requirements/ReqIFDal/ThingToReqIfMapper.cs
@@ -1,6 +1,6 @@
 ﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="ThingToReqIfMapper.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2021 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski
 //
@@ -29,6 +29,7 @@ namespace CDP4Requirements.ReqIFDal
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Security;
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
@@ -83,9 +84,49 @@ namespace CDP4Requirements.ReqIFDal
         public const string RequirementTextAttributeDefName = "Requirement Text";
 
         /// <summary>
+        /// The <see cref="AttributeDefinition.LongName"/> for the requirement text in XHTML (rich-text) form.
+        /// This uses the prostep ivip reserved name so that tools such as DOORS and Capella recognize it as the
+        /// requirement's rich text on import.
+        /// </summary>
+        public const string RequirementTextXhtmlAttributeDefName = "ReqIF.Text";
+
+        /// <summary>
         /// The <see cref="AttributeDefinition.LongName"/> for the <see cref="Requirement.IsDeprecated"/> and <see cref="RequirementsSpecification.IsDeprecated"/>
         /// </summary>
         public const string IsDeprecatedAttributeDefName = "IsDeprecated";
+
+        /// <summary>
+        /// The prostep ivip reserved <see cref="AttributeDefinition.LongName"/> for the name, used in the
+        /// <see cref="ReqIfExportProfile.DoorsCapella"/> profile so that DOORS and Capella map it to their name field.
+        /// </summary>
+        public const string ReqIfNameAttributeDefName = "ReqIF.Name";
+
+        /// <summary>
+        /// The prostep ivip reserved <see cref="AttributeDefinition.LongName"/> for the external identifier (short-name),
+        /// used in the <see cref="ReqIfExportProfile.DoorsCapella"/> profile.
+        /// </summary>
+        public const string ReqIfForeignIdAttributeDefName = "ReqIF.ForeignID";
+
+        /// <summary>
+        /// Gets or sets the <see cref="ReqIfExportProfile"/> that the export targets. Defaults to
+        /// <see cref="ReqIfExportProfile.DoorsCapella"/>.
+        /// </summary>
+        public ReqIfExportProfile Profile { get; set; } = ReqIfExportProfile.DoorsCapella;
+
+        /// <summary>
+        /// Gets the profile-dependent <see cref="AttributeDefinition.LongName"/> for the name attribute.
+        /// </summary>
+        public string NameAttributeName => this.Profile == ReqIfExportProfile.DoorsCapella ? ReqIfNameAttributeDefName : NameAttributeDefName;
+
+        /// <summary>
+        /// Gets the profile-dependent <see cref="AttributeDefinition.LongName"/> for the short-name attribute.
+        /// </summary>
+        public string ShortNameAttributeName => this.Profile == ReqIfExportProfile.DoorsCapella ? ReqIfForeignIdAttributeDefName : ShortNameAttributeDefName;
+
+        /// <summary>
+        /// Gets a value indicating whether the requirement text should also be exported as rich-text (XHTML).
+        /// </summary>
+        public bool ExportXhtmlText => this.Profile == ReqIfExportProfile.DoorsCapella;
 
         /// <summary>
         /// Creates a new instance of the <see cref="ThingToReqIfMapper"/> classs
@@ -116,6 +157,29 @@ namespace CDP4Requirements.ReqIFDal
             Description = "A boolean datatype",
             LastChange = DateTime.Now
         };
+
+        /// <summary>
+        /// The <see cref="DatatypeDefinitionXHTML"/> used for the rich-text (XHTML) representation of the requirement text
+        /// </summary>
+        public readonly DatatypeDefinitionXHTML XhtmlDatatypeDefinition = new()
+        {
+            LongName = "XHTML",
+            Identifier = "b1f4a1d6-8f3a-4a0e-9d21-6f0c0a3b2e77",
+            Description = "An XHTML datatype",
+            LastChange = DateTime.UtcNow
+        };
+
+        /// <summary>
+        /// Wraps plain text in a self-contained XHTML <c>div</c> (declaring the XHTML namespace locally) so that it is a
+        /// valid <see cref="AttributeValueXHTML"/> value. ReqIFSharp writes the value verbatim and does not declare the
+        /// XHTML namespace itself, so the namespace must be carried on the element.
+        /// </summary>
+        /// <param name="text">The plain text to wrap</param>
+        /// <returns>The XHTML string representation</returns>
+        public static string ToXhtmlDiv(string text)
+        {
+            return $"<div xmlns=\"http://www.w3.org/1999/xhtml\">{SecurityElement.Escape(text ?? string.Empty)}</div>";
+        }
 
         /// <summary>
         /// Returns a <see cref="SpecObjectType"/> associated to a <see cref="RequirementsGroup"/> and a set of rules
@@ -195,25 +259,25 @@ namespace CDP4Requirements.ReqIFDal
         }
 
         /// <summary>
-        /// Returns the <see cref="SpecObjectType"/> corresponding to a <see cref="Requirement"/>
+        /// Returns the single <see cref="SpecObjectType"/> shared by all <see cref="Requirement"/>s that have the same
+        /// set of applied <see cref="ParameterizedCategoryRule"/>s.
         /// </summary>
-        /// <param name="requirement">The <see cref="Requirement"/></param>
-        /// <param name="appliedRules">The applied <see cref="ParameterizedCategoryRule"/></param>
+        /// <param name="appliedRules">The applied <see cref="ParameterizedCategoryRule"/>s that name the type</param>
+        /// <param name="parameterTypes">
+        /// The union of all <see cref="ParameterType"/>s used by the requirements that share this type; each becomes an
+        /// optional attribute definition so that a single type can represent requirements with different parameters
+        /// (as ReqIF tools such as DOORS and Capella expect), rather than one type per parameter combination.
+        /// </param>
         /// <param name="parameterTypeMap">The map of <see cref="ParameterType"/> to <see cref="DatatypeDefinition"/></param>
         /// <returns>the <see cref="SpecObjectType"/></returns>
-        public SpecObjectType ToReqIfSpecObjectType(Requirement requirement, IReadOnlyCollection<ParameterizedCategoryRule> appliedRules, IReadOnlyDictionary<ParameterType, DatatypeDefinition> parameterTypeMap)
+        public SpecObjectType ToReqIfSpecObjectType(IReadOnlyCollection<ParameterizedCategoryRule> appliedRules, IReadOnlyCollection<ParameterType> parameterTypes, IReadOnlyDictionary<ParameterType, DatatypeDefinition> parameterTypeMap)
         {
-            if (requirement == null)
-            {
-                throw new ArgumentNullException(nameof(requirement));
-            }
-
             var specObjectType = new SpecObjectType()
             {
                 Identifier = Guid.NewGuid().ToString(),
-                LongName = appliedRules.Any() ? string.Join(", ", appliedRules.Select(r => r.ShortName)) : requirement.ClassKind.ToString(),
+                LongName = appliedRules.Any() ? string.Join(", ", appliedRules.Select(r => r.ShortName)) : ClassKind.Requirement.ToString(),
                 LastChange = DateTime.UtcNow,
-                Description = appliedRules.Any() ? string.Join(", ", appliedRules.Select(r => r.Name)) : requirement.ClassKind.ToString()
+                Description = appliedRules.Any() ? string.Join(", ", appliedRules.Select(r => r.Name)) : ClassKind.Requirement.ToString()
             };
 
             this.AddCommonAttributeDefinition(specObjectType);
@@ -229,6 +293,20 @@ namespace CDP4Requirements.ReqIFDal
 
             specObjectType.SpecAttributes.Add(requirementAttDefinition);
 
+            if (this.ExportXhtmlText)
+            {
+                var requirementXhtmlAttDefinition = new AttributeDefinitionXHTML
+                {
+                    LongName = RequirementTextXhtmlAttributeDefName,
+                    LastChange = DateTime.UtcNow,
+                    Description = "The Requirement Text (rich-text) Attribute Definition",
+                    Identifier = Guid.NewGuid().ToString(),
+                    Type = this.XhtmlDatatypeDefinition
+                };
+
+                specObjectType.SpecAttributes.Add(requirementXhtmlAttDefinition);
+            }
+
             var isDeprecatedAttributeDefinition = new AttributeDefinitionBoolean()
             {
                 LongName = IsDeprecatedAttributeDefName,
@@ -240,13 +318,8 @@ namespace CDP4Requirements.ReqIFDal
 
             specObjectType.SpecAttributes.Add(isDeprecatedAttributeDefinition);
 
-            // set the attribute-definition
-            var parameterTypes = appliedRules.SelectMany(r => r.ParameterType).ToList();
-            var requirementParameterTypes = requirement.ParameterValue.Select(spv => spv.ParameterType);
-
-            parameterTypes.AddRange(requirementParameterTypes);
-
-            foreach (var parameterType in parameterTypes.Distinct())
+            // one optional attribute definition per parameter type in the union
+            foreach (var parameterType in parameterTypes.Where(x => x != null).Distinct())
             {
                 var attibuteDef = this.ToReqIfAttributeDefinition(parameterType, parameterTypeMap);
                 specObjectType.SpecAttributes.Add(attibuteDef);
@@ -304,6 +377,21 @@ namespace CDP4Requirements.ReqIFDal
                 };
 
                 specObject.Values.Add(requirementValue);
+
+                // Also add the rich-text (XHTML) representation so tools such as DOORS and Capella render it as
+                // formatted text; the plain string above is kept so that the COMET importer keeps round-tripping.
+                if (this.ExportXhtmlText)
+                {
+                    var xhtmlAttributeDefinition = (AttributeDefinitionXHTML)specObjectType.SpecAttributes.Single(def => def.DatatypeDefinition == this.XhtmlDatatypeDefinition && def.LongName == RequirementTextXhtmlAttributeDefName);
+
+                    var requirementXhtmlValue = new AttributeValueXHTML
+                    {
+                        TheValue = ToXhtmlDiv(definition.Content),
+                        Definition = xhtmlAttributeDefinition
+                    };
+
+                    specObject.Values.Add(requirementXhtmlValue);
+                }
             }
 
             // Add extra AttributeValue corresponding to the isDeprecated property            
@@ -892,7 +980,7 @@ namespace CDP4Requirements.ReqIFDal
                 Type = this.TextDatatypeDefinition,
                 Description = "The Short-Name Attribute",
                 LastChange = DateTime.UtcNow,
-                LongName = ShortNameAttributeDefName
+                LongName = this.ShortNameAttributeName
             };
 
             spectType.SpecAttributes.Add(shortNameAttributeDef);
@@ -903,7 +991,7 @@ namespace CDP4Requirements.ReqIFDal
                 Type = this.TextDatatypeDefinition,
                 Description = "The Name Attribute",
                 LastChange = DateTime.UtcNow,
-                LongName = NameAttributeDefName
+                LongName = this.NameAttributeName
             };
 
             spectType.SpecAttributes.Add(nameAttributeDef);
@@ -927,8 +1015,8 @@ namespace CDP4Requirements.ReqIFDal
         /// <param name="thing">The associated <see cref="ICategorizableThing"/></param>
         private void SetCommonAttributeValues(SpecElementWithAttributes elementWithAttributes, ICategorizableThing thing)
         {
-            var shortNameType = (AttributeDefinitionString)elementWithAttributes.SpecType.SpecAttributes.Single(x => x.DatatypeDefinition == this.TextDatatypeDefinition && x.LongName == ShortNameAttributeDefName);
-            var nameType = (AttributeDefinitionString)elementWithAttributes.SpecType.SpecAttributes.Single(x => x.DatatypeDefinition == this.TextDatatypeDefinition && x.LongName == NameAttributeDefName);
+            var shortNameType = (AttributeDefinitionString)elementWithAttributes.SpecType.SpecAttributes.Single(x => x.DatatypeDefinition == this.TextDatatypeDefinition && x.LongName == this.ShortNameAttributeName);
+            var nameType = (AttributeDefinitionString)elementWithAttributes.SpecType.SpecAttributes.Single(x => x.DatatypeDefinition == this.TextDatatypeDefinition && x.LongName == this.NameAttributeName);
             var categoryType = (AttributeDefinitionString)elementWithAttributes.SpecType.SpecAttributes.Single(x => x.DatatypeDefinition == this.TextDatatypeDefinition && x.LongName == CategoryAttributeDefName);
 
             var castthing = (Thing)thing;

--- a/Requirements/ReqIFDal/ThingToReqIfMapper.cs
+++ b/Requirements/ReqIFDal/ThingToReqIfMapper.cs
@@ -109,9 +109,9 @@ namespace CDP4Requirements.ReqIFDal
 
         /// <summary>
         /// Gets or sets the <see cref="ReqIfExportProfile"/> that the export targets. Defaults to
-        /// <see cref="ReqIfExportProfile.DoorsCapella"/>.
+        /// <see cref="ReqIfExportProfile.Omg"/>.
         /// </summary>
-        public ReqIfExportProfile Profile { get; set; } = ReqIfExportProfile.DoorsCapella;
+        public ReqIfExportProfile Profile { get; set; } = ReqIfExportProfile.Omg;
 
         /// <summary>
         /// Gets the profile-dependent <see cref="AttributeDefinition.LongName"/> for the name attribute.

--- a/Requirements/ReqIFDal/ThingToReqIfMapper.cs
+++ b/Requirements/ReqIFDal/ThingToReqIfMapper.cs
@@ -751,6 +751,7 @@ namespace CDP4Requirements.ReqIFDal
             }
 
             attributeDefinition.Identifier = Guid.NewGuid().ToString();
+            attributeDefinition.LongName = parameterType.ShortName;
             return attributeDefinition;
         }
 

--- a/Requirements/ViewModels/ReqIF/ParameterTypeMappingDialogViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/ParameterTypeMappingDialogViewModel.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterTypeMappingDialogViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2022 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
 //
@@ -30,6 +30,8 @@ namespace CDP4Requirements.ViewModels
     using System.Linq;
     using System.Reactive;
     using System.Windows.Input;
+
+    using CDP4Requirements.Rdl;
 
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
@@ -230,7 +232,9 @@ namespace CDP4Requirements.ViewModels
         {
             this.CreateParameterTypeCommands.Clear();
 
-            if (this.SelectedRow == null)
+            // only the datatype-definition rows can create a parameter type; the enum-value child rows (the literals of
+            // an enumeration) cannot, so no create commands are offered for them.
+            if (this.SelectedRow == null || !(this.SelectedRow.Identifiable is DatatypeDefinition))
             {
                 return;
             }
@@ -315,12 +319,14 @@ namespace CDP4Requirements.ViewModels
             if (enumDatatype != null)
             {
                 var enumParameterType = new EnumerationParameterType { Name = enumDatatype.LongName };
+                var usedShortNames = new HashSet<string>();
+
                 foreach (var specifiedValue in enumDatatype.SpecifiedValues.OrderBy(x => x.Properties.Key))
                 {
                     var enumerationDefinition = new EnumerationValueDefinition
                     {
                         Name = specifiedValue.LongName,
-                        ShortName = specifiedValue.Properties.OtherContent
+                        ShortName = CreateUniqueEnumValueShortName(specifiedValue.LongName, usedShortNames)
                     };
 
                     enumParameterType.ValueDefinition.Add(enumerationDefinition);
@@ -346,6 +352,38 @@ namespace CDP4Requirements.ViewModels
             this.PopulateParameterTypes();
             ((DatatypeDefinitionMappingRowViewModel)this.SelectedRow).FilterPossibleParameterTypes();
             this.CastSelectedRow.MappedThing = this.ParameterTypes.Single(x => x.Iid == parameterType.Iid);
+        }
+
+        /// <summary>
+        /// Derives a valid and unique <see cref="CDP4Common.CommonData.DefinedThing.ShortName"/> for an
+        /// <see cref="EnumerationValueDefinition"/> from its name.
+        /// </summary>
+        /// <param name="name">The name of the <see cref="EnumValue"/> that is being mapped</param>
+        /// <param name="usedShortNames">The short-names already assigned to the other value definitions of the same <see cref="EnumerationParameterType"/></param>
+        /// <returns>
+        /// A short-name that follows the short-name validation rules and is unique within the <see cref="EnumerationParameterType"/>.
+        /// The ReqIF <c>OTHER-CONTENT</c> is not used as it frequently contains free text (e.g. "Other content for: ordinary")
+        /// that is not a valid short-name.
+        /// </returns>
+        private static string CreateUniqueEnumValueShortName(string name, ISet<string> usedShortNames)
+        {
+            var candidate = string.IsNullOrWhiteSpace(name) ? string.Empty : VandVRdlManifest.ToShortName(name);
+
+            if (string.IsNullOrEmpty(candidate))
+            {
+                candidate = "value";
+            }
+
+            var uniqueShortName = candidate;
+            var counter = 1;
+
+            while (!usedShortNames.Add(uniqueShortName))
+            {
+                uniqueShortName = $"{candidate}_{counter}";
+                counter++;
+            }
+
+            return uniqueShortName;
         }
 
         /// <summary>

--- a/Requirements/ViewModels/ReqIF/ReqIfExportDialogViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/ReqIfExportDialogViewModel.cs
@@ -69,6 +69,11 @@ namespace CDP4Requirements.ViewModels
         private bool includeDeprecated;
 
         /// <summary>
+        /// Backing field for <see cref="SelectedFormat"/>
+        /// </summary>
+        private ReqIfExportProfile selectedFormat = ReqIfExportProfile.DoorsCapella;
+
+        /// <summary>
         /// Backing field for <see cref="SelectedIteration"/>
         /// </summary>
         private ReqIfExportIterationRowViewModel selectedIteration;
@@ -141,6 +146,8 @@ namespace CDP4Requirements.ViewModels
 
             this.Sessions = sessions.ToList();
             this.Iterations = new ReactiveList<ReqIfExportIterationRowViewModel>();
+            this.RequirementsSpecifications = new ReactiveList<ReqIfExportRequirementsSpecificationRowViewModel>();
+            this.SpecObjectTypesPreview = new ReactiveList<ReqIfExportSpecObjectTypeRowViewModel>();
             this.fileDialogService = fileDialogService;
             this.serializer = serializer;
 
@@ -149,10 +156,18 @@ namespace CDP4Requirements.ViewModels
                 this.Iterations.Add(new ReqIfExportIterationRowViewModel(iteration));
             }
 
+            this.WhenAnyValue(vm => vm.SelectedIteration).Subscribe(_ => this.PopulateRequirementsSpecifications());
+
+            this.WhenAnyValue(vm => vm.IncludeDeprecated).Subscribe(_ => this.PopulateRequirementsSpecifications());
+
             var canOk = this.WhenAnyValue(
                 vm => vm.Path,
                 vm => vm.SelectedIteration,
                 (path, iteration) => iteration != null && !string.IsNullOrEmpty(path));
+
+            var canPreview = this.WhenAnyValue(vm => vm.SelectedIteration).Select(iteration => iteration != null);
+
+            this.PreviewSpecObjectTypesCommand = ReactiveCommandCreator.CreateAsyncTask(this.ExecutePreviewSpecObjectTypes, canPreview);
 
             this.OkCommand = ReactiveCommandCreator.CreateAsyncTask(this.ExecuteOk, canOk);
 
@@ -215,6 +230,16 @@ namespace CDP4Requirements.ViewModels
         public ReactiveList<ReqIfExportIterationRowViewModel> Iterations { get; private set; }
 
         /// <summary>
+        /// Gets the selectable <see cref="RequirementsSpecification"/> rows of the <see cref="SelectedIteration"/>
+        /// </summary>
+        public ReactiveList<ReqIfExportRequirementsSpecificationRowViewModel> RequirementsSpecifications { get; private set; }
+
+        /// <summary>
+        /// Gets the preview of the <c>SpecObjectType</c>s that the exporter will produce for the current selection
+        /// </summary>
+        public ReactiveList<ReqIfExportSpecObjectTypeRowViewModel> SpecObjectTypesPreview { get; private set; }
+
+        /// <summary>
         /// Gets or sets the selected iteration to export
         /// </summary>
         public ReqIfExportIterationRowViewModel SelectedIteration
@@ -239,6 +264,24 @@ namespace CDP4Requirements.ViewModels
         {
             get => this.includeDeprecated;
             set => this.RaiseAndSetIfChanged(ref this.includeDeprecated, value);
+        }
+
+        /// <summary>
+        /// Gets the available export formats that can be selected, with human-readable names
+        /// </summary>
+        public IEnumerable<ReqIfExportProfileRowViewModel> PossibleFormats { get; } = new[]
+        {
+            new ReqIfExportProfileRowViewModel(ReqIfExportProfile.DoorsCapella, "ReqIF Implementation Guide (DOORS and Capella)"),
+            new ReqIfExportProfileRowViewModel(ReqIfExportProfile.Omg, "Original OMG Format")
+        };
+
+        /// <summary>
+        /// Gets or sets the <see cref="ReqIfExportProfile"/> that the export targets
+        /// </summary>
+        public ReqIfExportProfile SelectedFormat
+        {
+            get => this.selectedFormat;
+            set => this.RaiseAndSetIfChanged(ref this.selectedFormat, value);
         }
 
         /// <summary>
@@ -267,6 +310,11 @@ namespace CDP4Requirements.ViewModels
         public ReactiveCommand<Unit, Unit> BrowseCommand { get; private set; }
 
         /// <summary>
+        /// Gets the command that previews the <c>SpecObjectType</c>s that will be exported for the current selection
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> PreviewSpecObjectTypesCommand { get; private set; }
+
+        /// <summary>
         /// Executes the Ok Command
         /// </summary>
         public async Task ExecuteOk()
@@ -284,6 +332,12 @@ namespace CDP4Requirements.ViewModels
 
             try
             {
+                if (!this.RequirementsSpecifications.Any(x => x.IsSelected))
+                {
+                    this.ErrorMessage = "Select at least one requirements specification to export.";
+                    return;
+                }
+
                 this.LoadingMessage = "Pre checking model validity...";
 
                 if (!await Task.Run(this.CheckModelValidity, this.cancellationToken))
@@ -328,9 +382,106 @@ namespace CDP4Requirements.ViewModels
                     var session = this.Sessions.Single(x => x.Assembler.Cache == this.SelectedIteration.Iteration.Cache);
                     var reqifBuilder = new ReqIFBuilder();
 
-                    return reqifBuilder.BuildReqIF(session, this.SelectedIteration.Iteration, this.IncludeDeprecated);
+                    var selectedRequirementsSpecifications =
+                        this.RequirementsSpecifications.Where(x => x.IsSelected).Select(x => x.RequirementsSpecification).ToList();
+
+                    return reqifBuilder.BuildReqIF(session, this.SelectedIteration.Iteration, this.IncludeDeprecated, selectedRequirementsSpecifications, this.SelectedFormat);
                 },
                 this.cancellationToken);
+        }
+
+        /// <summary>
+        /// Builds the ReqIF in-memory for the current selection and populates <see cref="SpecObjectTypesPreview"/> with
+        /// the <c>SpecObjectType</c>s that the exporter would produce, together with the number of requirements or groups
+        /// that map to each of them.
+        /// </summary>
+        /// <returns>An awaitable <see cref="Task"/></returns>
+        private async Task ExecutePreviewSpecObjectTypes()
+        {
+            this.SpecObjectTypesPreview.Clear();
+            this.ErrorMessage = string.Empty;
+
+            var selectedRequirementsSpecifications =
+                this.RequirementsSpecifications.Where(x => x.IsSelected).Select(x => x.RequirementsSpecification).ToList();
+
+            if (!selectedRequirementsSpecifications.Any())
+            {
+                this.ErrorMessage = "Select at least one requirements specification to preview.";
+                return;
+            }
+
+            try
+            {
+                this.IsBusy = true;
+                this.LoadingMessage = "Building the type preview...";
+
+                var session = this.Sessions.Single(x => x.Assembler.Cache == this.SelectedIteration.Iteration.Cache);
+
+                var reqif = await Task.Run(() => new ReqIFBuilder().BuildReqIF(session, this.SelectedIteration.Iteration, this.IncludeDeprecated, selectedRequirementsSpecifications, this.SelectedFormat));
+
+                var specObjects = reqif.CoreContent.SpecObjects;
+
+                // the attributes every requirement/group type shares; the remaining attributes are the
+                // parameter-derived ones that explain why two same-named types are exported separately.
+                var commonAttributeNames = new HashSet<string>
+                {
+                    ThingToReqIfMapper.ShortNameAttributeDefName,
+                    ThingToReqIfMapper.NameAttributeDefName,
+                    ThingToReqIfMapper.ReqIfForeignIdAttributeDefName,
+                    ThingToReqIfMapper.ReqIfNameAttributeDefName,
+                    ThingToReqIfMapper.CategoryAttributeDefName,
+                    ThingToReqIfMapper.RequirementTextAttributeDefName,
+                    ThingToReqIfMapper.RequirementTextXhtmlAttributeDefName,
+                    ThingToReqIfMapper.IsDeprecatedAttributeDefName
+                };
+
+                foreach (var specObjectType in reqif.CoreContent.SpecTypes.OfType<SpecObjectType>().OrderBy(x => x.LongName))
+                {
+                    var numberOfObjects = specObjects.Count(x => x.Type == specObjectType);
+
+                    var distinguishingAttributes = specObjectType.SpecAttributes
+                        .Select(x => x.LongName)
+                        .Where(x => !commonAttributeNames.Contains(x))
+                        .ToList();
+
+                    var distinguishingAttributesText = distinguishingAttributes.Any() ? string.Join(", ", distinguishingAttributes) : "(no extra parameters)";
+
+                    this.SpecObjectTypesPreview.Add(new ReqIfExportSpecObjectTypeRowViewModel(specObjectType.LongName, numberOfObjects, distinguishingAttributesText));
+                }
+            }
+            catch (Exception ex)
+            {
+                this.ErrorMessage = ex.Message;
+            }
+            finally
+            {
+                this.LoadingMessage = string.Empty;
+                this.IsBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// Populates the <see cref="RequirementsSpecifications"/> from the <see cref="SelectedIteration"/>,
+        /// selecting all of them by default.
+        /// </summary>
+        private void PopulateRequirementsSpecifications()
+        {
+            this.RequirementsSpecifications.Clear();
+            this.SpecObjectTypesPreview.Clear();
+
+            if (this.SelectedIteration == null)
+            {
+                return;
+            }
+
+            var requirementsSpecifications = this.SelectedIteration.Iteration.RequirementsSpecification
+                .Where(x => this.IncludeDeprecated || !x.IsDeprecated)
+                .OrderBy(x => x.ShortName);
+
+            foreach (var requirementsSpecification in requirementsSpecifications)
+            {
+                this.RequirementsSpecifications.Add(new ReqIfExportRequirementsSpecificationRowViewModel(requirementsSpecification));
+            }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/ReqIF/ReqIfExportDialogViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/ReqIfExportDialogViewModel.cs
@@ -156,9 +156,9 @@ namespace CDP4Requirements.ViewModels
                 this.Iterations.Add(new ReqIfExportIterationRowViewModel(iteration));
             }
 
-            this.WhenAnyValue(vm => vm.SelectedIteration).Subscribe(_ => this.PopulateRequirementsSpecifications());
+            this.Subscriptions.Add(this.WhenAnyValue(vm => vm.SelectedIteration).Subscribe(_ => this.PopulateRequirementsSpecifications()));
 
-            this.WhenAnyValue(vm => vm.IncludeDeprecated).Subscribe(_ => this.PopulateRequirementsSpecifications());
+            this.Subscriptions.Add(this.WhenAnyValue(vm => vm.IncludeDeprecated).Subscribe(_ => this.PopulateRequirementsSpecifications()));
 
             var canOk = this.WhenAnyValue(
                 vm => vm.Path,
@@ -171,11 +171,11 @@ namespace CDP4Requirements.ViewModels
 
             this.OkCommand = ReactiveCommandCreator.CreateAsyncTask(this.ExecuteOk, canOk);
 
-            this.OkCommand.ThrownExceptions.Select(ex => ex).Subscribe(
+            this.Subscriptions.Add(this.OkCommand.ThrownExceptions.Select(ex => ex).Subscribe(
                 x =>
             {
                 this.ErrorMessage = x.Message;
-            });
+            }));
 
             this.BrowseCommand = ReactiveCommandCreator.Create(this.ExecuteBrowse);
 
@@ -185,11 +185,11 @@ namespace CDP4Requirements.ViewModels
 
             this.CancelReqIfCommand = ReactiveCommandCreator.Create();
 
-            this.CancelReqIfCommand.Subscribe(_ =>
+            this.Subscriptions.Add(this.CancelReqIfCommand.Subscribe(_ =>
             {
                 this.cancellationTokenSource?.Cancel();
                 this.LoadingMessage = "Cancelling...";
-            });
+            }));
         }
 
         /// <summary>

--- a/Requirements/ViewModels/ReqIF/ReqIfExportDialogViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/ReqIfExportDialogViewModel.cs
@@ -71,7 +71,7 @@ namespace CDP4Requirements.ViewModels
         /// <summary>
         /// Backing field for <see cref="SelectedFormat"/>
         /// </summary>
-        private ReqIfExportProfile selectedFormat = ReqIfExportProfile.DoorsCapella;
+        private ReqIfExportProfile selectedFormat = ReqIfExportProfile.Omg;
 
         /// <summary>
         /// Backing field for <see cref="SelectedIteration"/>
@@ -271,8 +271,8 @@ namespace CDP4Requirements.ViewModels
         /// </summary>
         public IEnumerable<ReqIfExportProfileRowViewModel> PossibleFormats { get; } = new[]
         {
-            new ReqIfExportProfileRowViewModel(ReqIfExportProfile.DoorsCapella, "ReqIF Implementation Guide (DOORS and Capella)"),
-            new ReqIfExportProfileRowViewModel(ReqIfExportProfile.Omg, "Original OMG Format")
+            new ReqIfExportProfileRowViewModel(ReqIfExportProfile.Omg, "Original OMG Format"),
+            new ReqIfExportProfileRowViewModel(ReqIfExportProfile.DoorsCapella, "prostep ivip Implementation Guide (DOORS and Capella)")
         };
 
         /// <summary>

--- a/Requirements/ViewModels/ReqIF/ReqIfImportDialogViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/ReqIfImportDialogViewModel.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReqIfImportDialogViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2022 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
 //
@@ -302,7 +302,7 @@ namespace CDP4Requirements.ViewModels
         /// </summary>
         private void ExecuteBrowse()
         {
-            var result = this.fileDialogService.GetOpenFileDialog(true, true, false, "ReqIF files (*.reqif, *.xml)|*.reqif; *.xml|All Files (*.*)|*.*", ".reqif", this.Path, 1);
+            var result = this.fileDialogService.GetOpenFileDialog(true, true, false, "ReqIF files (*.reqif, *.reqifz, *.zip)|*.reqif; *.reqifz; *.zip|All Files (*.*)|*.*", ".reqif", this.Path, 1);
             
             if (result == null)
             {

--- a/Requirements/ViewModels/ReqIF/ReqIfImportDialogViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/ReqIfImportDialogViewModel.cs
@@ -302,7 +302,7 @@ namespace CDP4Requirements.ViewModels
         /// </summary>
         private void ExecuteBrowse()
         {
-            var result = this.fileDialogService.GetOpenFileDialog(true, true, false, "ReqIF files (*.reqif, *.reqifz, *.zip)|*.reqif; *.reqifz; *.zip|All Files (*.*)|*.*", ".reqif", this.Path, 1);
+            var result = this.fileDialogService.GetOpenFileDialog(true, true, false, "ReqIF files (*.reqif, *.reqifz, *.zip, *.xml)|*.reqif; *.reqifz; *.zip; *.xml|All Files (*.*)|*.*", ".reqif", this.Path, 1);
             
             if (result == null)
             {

--- a/Requirements/ViewModels/ReqIF/Rows/Import/AttributeDefinitionMappingRowViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/Rows/Import/AttributeDefinitionMappingRowViewModel.cs
@@ -1,8 +1,27 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AttributeDefinitionMappingRowViewModel.cs" company="Starion Group S.A.">
-//   Copyright (c) 2015 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4Requirements.ViewModels
 {
@@ -44,6 +63,35 @@ namespace CDP4Requirements.ViewModels
                 this.UpdateIsMapped();
                 refreshValidation();
             });
+
+            var defaultMapKind = GetDefaultMapKind(attributeDefinition.LongName);
+
+            if (defaultMapKind != AttributeDefinitionMapKind.NONE)
+            {
+                this.AttributeDefinitionMapKind = defaultMapKind;
+            }
+        }
+
+        /// <summary>
+        /// Returns the <see cref="AttributeDefinitionMapKind"/> that an <see cref="AttributeDefinition"/> should default to
+        /// based on its name. The prostep ivip reserved <c>ReqIF.*</c> names (used by the COMET DOORS/Capella export as
+        /// well as by DOORS and Capella themselves) are pre-mapped so that such files import without manual mapping.
+        /// </summary>
+        /// <param name="longName">The <see cref="AttributeDefinition.LongName"/></param>
+        /// <returns>The default <see cref="AttributeDefinitionMapKind"/></returns>
+        private static AttributeDefinitionMapKind GetDefaultMapKind(string longName)
+        {
+            switch (longName)
+            {
+                case ThingToReqIfMapper.ReqIfNameAttributeDefName:
+                    return AttributeDefinitionMapKind.NAME;
+                case ThingToReqIfMapper.ReqIfForeignIdAttributeDefName:
+                    return AttributeDefinitionMapKind.SHORTNAME;
+                case ThingToReqIfMapper.RequirementTextXhtmlAttributeDefName:
+                    return AttributeDefinitionMapKind.FIRST_DEFINITION;
+                default:
+                    return AttributeDefinitionMapKind.NONE;
+            }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/ReqIF/Rows/ReqIfExportProfileRowViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/Rows/ReqIfExportProfileRowViewModel.cs
@@ -1,0 +1,57 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ReqIfExportProfileRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Requirements.ViewModels
+{
+    using CDP4Requirements.ReqIFDal;
+
+    /// <summary>
+    /// A selectable export-format row that pairs a <see cref="ReqIfExportProfile"/> with a human-readable name for
+    /// display in the export dialog.
+    /// </summary>
+    public class ReqIfExportProfileRowViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReqIfExportProfileRowViewModel"/> class
+        /// </summary>
+        /// <param name="profile">The <see cref="ReqIfExportProfile"/> represented</param>
+        /// <param name="displayName">The human-readable name shown to the user</param>
+        public ReqIfExportProfileRowViewModel(ReqIfExportProfile profile, string displayName)
+        {
+            this.Profile = profile;
+            this.DisplayName = displayName;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ReqIfExportProfile"/> represented by this row
+        /// </summary>
+        public ReqIfExportProfile Profile { get; }
+
+        /// <summary>
+        /// Gets the human-readable name shown to the user
+        /// </summary>
+        public string DisplayName { get; }
+    }
+}

--- a/Requirements/ViewModels/ReqIF/Rows/ReqIfExportRequirementsSpecificationRowViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/Rows/ReqIfExportRequirementsSpecificationRowViewModel.cs
@@ -1,0 +1,80 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ReqIfExportRequirementsSpecificationRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Requirements.ViewModels
+{
+    using CDP4Common.EngineeringModelData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// The <see cref="RequirementsSpecification"/> row in the ReqIF export view-model. It allows the user
+    /// to select which <see cref="RequirementsSpecification"/>s are included in the export.
+    /// </summary>
+    public class ReqIfExportRequirementsSpecificationRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="IsSelected"/>
+        /// </summary>
+        private bool isSelected;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReqIfExportRequirementsSpecificationRowViewModel"/> class
+        /// </summary>
+        /// <param name="requirementsSpecification">The <see cref="RequirementsSpecification"/> represented</param>
+        /// <param name="isSelected">A value indicating whether the <see cref="RequirementsSpecification"/> is selected for export. Defaults to true.</param>
+        public ReqIfExportRequirementsSpecificationRowViewModel(RequirementsSpecification requirementsSpecification, bool isSelected = true)
+        {
+            this.RequirementsSpecification = requirementsSpecification;
+            this.Name = requirementsSpecification.Name;
+            this.ShortName = requirementsSpecification.ShortName;
+            this.IsSelected = isSelected;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="RequirementsSpecification"/> represented by this row
+        /// </summary>
+        public RequirementsSpecification RequirementsSpecification { get; }
+
+        /// <summary>
+        /// Gets the name of the <see cref="RequirementsSpecification"/>
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the short-name of the <see cref="RequirementsSpecification"/>
+        /// </summary>
+        public string ShortName { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="RequirementsSpecification"/> is selected for export
+        /// </summary>
+        public bool IsSelected
+        {
+            get => this.isSelected;
+            set => this.RaiseAndSetIfChanged(ref this.isSelected, value);
+        }
+    }
+}

--- a/Requirements/ViewModels/ReqIF/Rows/ReqIfExportSpecObjectTypeRowViewModel.cs
+++ b/Requirements/ViewModels/ReqIF/Rows/ReqIfExportSpecObjectTypeRowViewModel.cs
@@ -1,0 +1,67 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ReqIfExportSpecObjectTypeRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Requirements.ViewModels
+{
+    /// <summary>
+    /// A read-only preview row describing a <c>SpecObjectType</c> that the ReqIF exporter will produce for the
+    /// current export selection. It lets the user see which types (and therefore which rules) drive the export
+    /// before writing the file.
+    /// </summary>
+    public class ReqIfExportSpecObjectTypeRowViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReqIfExportSpecObjectTypeRowViewModel"/> class
+        /// </summary>
+        /// <param name="name">The name (<c>LONG-NAME</c>) of the <c>SpecObjectType</c> that will be exported</param>
+        /// <param name="numberOfObjects">The number of requirements or groups that are mapped to this type</param>
+        /// <param name="distinguishingAttributes">
+        /// The parameter-derived attributes that distinguish this type from the other types with the same name.
+        /// Two types can share a name (e.g. "Requirement") yet be exported separately because they carry different
+        /// parameters; this shows which parameters set them apart.
+        /// </param>
+        public ReqIfExportSpecObjectTypeRowViewModel(string name, int numberOfObjects, string distinguishingAttributes)
+        {
+            this.Name = name;
+            this.NumberOfObjects = numberOfObjects;
+            this.DistinguishingAttributes = distinguishingAttributes;
+        }
+
+        /// <summary>
+        /// Gets the name of the <c>SpecObjectType</c> that will be exported
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the number of requirements or groups that are mapped to this type
+        /// </summary>
+        public int NumberOfObjects { get; }
+
+        /// <summary>
+        /// Gets the parameter-derived attributes that distinguish this type from other types with the same name
+        /// </summary>
+        public string DistinguishingAttributes { get; }
+    }
+}

--- a/Requirements/Views/ReqIf/ReqIfExportDialog.xaml
+++ b/Requirements/Views/ReqIf/ReqIfExportDialog.xaml
@@ -10,11 +10,12 @@
     xmlns:views="clr-namespace:CDP4Composition.Views;assembly=CDP4Composition"
     xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
     xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
-    Title="Export to ReqIF file..." 
+    Title="Export to ReqIF file..."
     dx:ThemeManager.ThemeName="Seven"
     navigation:ExtendedDialogResultCloser.DialogResult="{Binding DialogResult}"
     Height="Auto"
-    Width="Auto">
+    Width="720"
+    SizeToContent="Height">
 
     <dx:DXWindow.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
@@ -64,10 +65,93 @@
                     </dxg:GridControl>
                 </dxlc:LayoutItem>
 
+                <dxlc:LayoutItem Label="Export format"
+                                 LabelPosition="Left"
+                                 ToolTip="The 'ReqIF Implementation Guide' format exports rich text (XHTML) and the reserved ReqIF.* attribute names so DOORS and Capella map them automatically; the 'Original OMG Format' exports plain OMG ReqIF with the native COMET names.">
+                    <dxe:ComboBoxEdit IsTextEditable="False"
+                                      MaxHeight="25"
+                                      DisplayMember="DisplayName"
+                                      ValueMember="Profile"
+                                      ItemsSource="{Binding PossibleFormats}"
+                                      EditValue="{Binding SelectedFormat, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </dxlc:LayoutItem>
+
+                <dxlc:LayoutItem LabelVerticalAlignment="Top"
+                                 LabelPosition="Top"
+                                 Label="Select the requirements specifications to export:">
+                    <dxg:GridControl AllowLiveDataShaping="False"
+                                     ItemsSource="{Binding RequirementsSpecifications}"
+                                     Height="120">
+                        <dxg:GridControl.View>
+                            <dxg:TableView HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Stretch"
+                                           AllowColumnMoving="False"
+                                           AllowEditing="True"
+                                           AllowGrouping="False"
+                                           AutoWidth="True"
+                                           NavigationStyle="Cell"
+                                           ShowGroupPanel="False"
+                                           IsDetailButtonVisibleBinding="{x:Null}" />
+                        </dxg:GridControl.View>
+                        <dxg:GridControl.Columns>
+                            <dxg:GridColumn Header=""
+                                            Width="30"
+                                            FixedWidth="True"
+                                            AllowEditing="True"
+                                            AllowAutoFilter="False"
+                                            AllowColumnFiltering="False"
+                                            AllowSorting="False">
+                                <dxg:GridColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <dxe:CheckEdit HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"
+                                                       IsChecked="{Binding RowData.Row.IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    </DataTemplate>
+                                </dxg:GridColumn.CellTemplate>
+                            </dxg:GridColumn>
+                            <dxg:GridColumn FieldName="Name" Header="Name" ReadOnly="True" />
+                            <dxg:GridColumn FieldName="ShortName" Header="Short Name" ReadOnly="True" />
+                        </dxg:GridControl.Columns>
+                    </dxg:GridControl>
+                </dxlc:LayoutItem>
+
                 <dxlc:LayoutItem>
                     <dxe:CheckEdit MaxHeight="25"
                                    Content="Include Deprecated"
                                    EditValue="{Binding IncludeDeprecated, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                </dxlc:LayoutItem>
+
+                <dxlc:LayoutItem>
+                    <Button MaxHeight="25"
+                            HorizontalAlignment="Left"
+                            Command="{Binding PreviewSpecObjectTypesCommand}"
+                            Content="Preview export types"
+                            ToolTip="Show the spec-object types (and the rules that drive them) that the exporter will produce for the current selection." />
+                </dxlc:LayoutItem>
+
+                <dxlc:LayoutItem LabelVerticalAlignment="Top"
+                                 LabelPosition="Top"
+                                 Label="Spec-object types that will be exported:">
+                    <dxg:GridControl AllowLiveDataShaping="False"
+                                     ItemsSource="{Binding SpecObjectTypesPreview}"
+                                     Height="100">
+                        <dxg:GridControl.View>
+                            <dxg:TableView HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Stretch"
+                                           AllowColumnMoving="False"
+                                           AllowEditing="False"
+                                           AllowGrouping="False"
+                                           AutoWidth="True"
+                                           ShowGroupPanel="False"
+                                           IsDetailButtonVisibleBinding="{x:Null}" />
+                        </dxg:GridControl.View>
+                        <dxg:GridControl.Columns>
+                            <dxg:GridColumn FieldName="Name" Header="Type Name" ReadOnly="True" />
+                            <dxg:GridColumn FieldName="NumberOfObjects" Header="Requirements / Groups" ReadOnly="True" />
+                            <dxg:GridColumn FieldName="DistinguishingAttributes" Header="Distinguishing parameters" ReadOnly="True"
+                                            ToolTip="Types with the same name are exported separately when they carry different parameters. This shows the parameters that set each type apart." />
+                        </dxg:GridControl.Columns>
+                    </dxg:GridControl>
                 </dxlc:LayoutItem>
 
                 <dxlc:LayoutItem AddColonToLabel="True" 

--- a/Requirements/Views/ReqIf/ReqIfExportDialog.xaml
+++ b/Requirements/Views/ReqIf/ReqIfExportDialog.xaml
@@ -13,9 +13,8 @@
     Title="Export to ReqIF file..."
     dx:ThemeManager.ThemeName="Seven"
     navigation:ExtendedDialogResultCloser.DialogResult="{Binding DialogResult}"
-    Height="Auto"
-    Width="720"
-    SizeToContent="Height">
+    Height="750"
+    Width="720">
 
     <dx:DXWindow.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
@@ -25,8 +24,9 @@
     </dxmvvm:Interaction.Behaviors>  
 
     <Grid>
-        <dxlc:LayoutControl Background="White" 
-                            Orientation="Vertical">
+        <dxlc:LayoutControl Background="White"
+                            Orientation="Vertical"
+                            ScrollBars="Auto">
             <dxlc:LayoutGroup Orientation="Vertical" 
                               Height="Auto"
                               View="GroupBox"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
#1487 Fixed the ReqIF Exporter to not have a specobjectType for each requirement. It makes a specObjectType per different combination of rules and simple parameter values.

