### PR TITLE
Fix #1480 and #1481 full error text in details and ruleVerificationDialog always active on creation

### DIFF
--- a/EngineeringModel.Tests/Dialogs/BuiltInRuleVerificationDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/BuiltInRuleVerificationDialogViewModelTestFixture.cs
@@ -183,6 +183,19 @@ namespace CDP4EngineeringModel.Tests.Dialogs
         }
 
         [Test]
+        public void VerifyThatOnCreateIsActiveDefaultsToTrue()
+        {
+            var newRuleVerification = new BuiltInRuleVerification(Guid.NewGuid(), this.cache, this.uri);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(this.iteration);
+            this.thingTransaction = new ThingTransaction(transactionContext, this.ruleVerificationList);
+
+            var viewModel = new BuiltInRuleVerificationDialogViewModel(newRuleVerification, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.ruleVerificationList, null);
+
+            Assert.IsTrue(viewModel.IsActive);
+        }
+
+        [Test]
         public void VerifyThatIfNameOfRuleMatchesAvailableRuleselectedRuleIsSet()
         {
             this.builtInRuleVerification.Name = this.builtInRuleName;

--- a/EngineeringModel.Tests/Dialogs/UserRuleVerificationDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/UserRuleVerificationDialogViewModelTestFixture.cs
@@ -182,6 +182,19 @@ namespace CDP4EngineeringModel.Tests.Dialogs
         }
 
         [Test]
+        public void VerifyThatOnCreateIsActiveDefaultsToTrue()
+        {
+            var newRuleVerification = new UserRuleVerification(Guid.NewGuid(), this.cache, this.uri);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(this.iteration);
+            var transaction = new ThingTransaction(transactionContext, this.ruleVerificationList);
+
+            var dialog = new UserRuleVerificationDialogViewModel(newRuleVerification, transaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.ruleVerificationList, null);
+
+            Assert.IsTrue(dialog.IsActive);
+        }
+
+        [Test]
         public void VerifyThatDeprecatedRulesAreHiddenWhenShowDeprecatedThingsIsOff()
         {
             this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(false);

--- a/EngineeringModel.Tests/ViewModels/RuleVerificationListBrowser/RuleVerificationListRowViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/RuleVerificationListBrowser/RuleVerificationListRowViewModelTestFixture.cs
@@ -441,6 +441,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.RuleVerificationListBrowser
 
             var violationRow = builtInRow.ContainedRows.OfType<RuleViolationRowViewModel>().Single();
             Assert.AreEqual(violation.Description, violationRow.Tooltip);
+            Assert.AreEqual(violation.Description, violationRow.Details);
 
             var violatingThingRow = violationRow.ContainedRows.OfType<ViolatingThingRowViewModel>().Single();
             Assert.AreEqual(elementDefinition, violatingThingRow.Thing);

--- a/EngineeringModel/ViewModels/Dialogs/BuiltInRuleVerificationDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/BuiltInRuleVerificationDialogViewModel.cs
@@ -143,6 +143,8 @@ namespace CDP4EngineeringModel.ViewModels
 
             if (this.dialogKind == ThingDialogKind.Create)
             {
+                this.IsActive = true;
+
                 var container = (RuleVerificationList)this.Container;
                 this.Owner = string.Format("{0} [{1}]", container.Owner.Name, container.Owner.ShortName);
             }

--- a/EngineeringModel/ViewModels/Dialogs/UserRuleVerificationDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/UserRuleVerificationDialogViewModel.cs
@@ -120,6 +120,8 @@ namespace CDP4EngineeringModel.ViewModels
 
             if (this.dialogKind == ThingDialogKind.Create)
             {
+                this.IsActive = true;
+
                 var container = (RuleVerificationList)this.Container;
                 this.Owner = string.Format("{0} [{1}]", container.Owner.Name, container.Owner.ShortName);
             }

--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleViolationRowViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleViolationRowViewModel.cs
@@ -84,6 +84,15 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
+        /// Update the <see cref="RowViewModelBase{T}.Details"/> so that the full, readable violation text is shown
+        /// in the details box at the bottom of the browser, rather than only the type of the selected row.
+        /// </summary>
+        protected override void UpdateDetails()
+        {
+            this.Details = this.Thing.Description;
+        }
+
+        /// <summary>
         /// Populates the child rows that represent the <see cref="Thing"/>s referenced by
         /// <see cref="RuleViolation.ViolatingThing"/>.
         /// </summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #1480 and #1481 full error text in details and ruleVerificationDialog always active on creation

