### PR TITLE
Feat #1490 Link files to elements

### DIFF
--- a/CDP4Composition.Tests/Diagram/NamedThingDiagramContentItemTestFixture.cs
+++ b/CDP4Composition.Tests/Diagram/NamedThingDiagramContentItemTestFixture.cs
@@ -25,8 +25,10 @@
 
 namespace CDP4Composition.Tests.Diagram
 {
+    using System;
     using System.Threading;
 
+    using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Composition.Diagram;
@@ -57,6 +59,19 @@ namespace CDP4Composition.Tests.Diagram
 
             Assert.AreEqual(this.domainOfExpertise, namedThingDiagramContentItem.Thing);
             Assert.AreEqual(this.domainOfExpertise, namedThingDiagramContentItem.Content);
+        }
+
+        [Test]
+        public void VerifyThatFileUsesCurrentRevisionNameForNameAndShortName()
+        {
+            // A File is not a (Short)NamedThing; the diagram item must show its current revision name (see GitHub issue #1490)
+            var file = new File();
+            file.FileRevision.Add(new FileRevision { Name = "geometry.stp", CreatedOn = new DateTime(2024, 6, 1) });
+
+            var namedThingDiagramContentItem = new NamedThingDiagramContentItem(file, new CDPMessageBus());
+
+            Assert.AreEqual("geometry.stp", namedThingDiagramContentItem.FullName);
+            Assert.AreEqual("geometry.stp", namedThingDiagramContentItem.ShortName);
         }
     }
 }

--- a/CDP4Composition.Tests/Diagram/NamedThingDiagramContentItemTestFixture.cs
+++ b/CDP4Composition.Tests/Diagram/NamedThingDiagramContentItemTestFixture.cs
@@ -70,8 +70,11 @@ namespace CDP4Composition.Tests.Diagram
 
             var namedThingDiagramContentItem = new NamedThingDiagramContentItem(file, new CDPMessageBus());
 
-            Assert.AreEqual("geometry.stp", namedThingDiagramContentItem.FullName);
-            Assert.AreEqual("geometry.stp", namedThingDiagramContentItem.ShortName);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual("geometry.stp", namedThingDiagramContentItem.FullName);
+                Assert.AreEqual("geometry.stp", namedThingDiagramContentItem.ShortName);
+            });
         }
     }
 }

--- a/CDP4Composition/Diagram/NamedThingDiagramContentItem.cs
+++ b/CDP4Composition/Diagram/NamedThingDiagramContentItem.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NamedThingDiagramContentItem.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
 //
@@ -89,6 +89,13 @@ namespace CDP4Composition.Diagram
             {
                 this.FullName = parameterBaseThing.UserFriendlyName;
                 this.ShortName = parameterBaseThing.UserFriendlyShortName;
+            }
+
+            // a File is not a (Short)NamedThing; its name lives on the current FileRevision (see GitHub issue #1490)
+            if (this.Thing is File file)
+            {
+                this.FullName = file.CurrentFileRevision?.Name;
+                this.ShortName = file.CurrentFileRevision?.Name;
             }
         }
 

--- a/CDP4Composition/Diagram/NamedThingDiagramContentItem.cs
+++ b/CDP4Composition/Diagram/NamedThingDiagramContentItem.cs
@@ -91,7 +91,6 @@ namespace CDP4Composition.Diagram
                 this.ShortName = parameterBaseThing.UserFriendlyShortName;
             }
 
-            // a File is not a (Short)NamedThing; its name lives on the current FileRevision (see GitHub issue #1490)
             if (this.Thing is File file)
             {
                 this.FullName = file.CurrentFileRevision?.Name;

--- a/CDP4Composition/Extensions/OwnedThingDialogExtensions.cs
+++ b/CDP4Composition/Extensions/OwnedThingDialogExtensions.cs
@@ -28,6 +28,7 @@ namespace CDP4Composition.Extensions
     using System.Collections.Generic;
     using System.Linq;
 
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
@@ -73,6 +74,33 @@ namespace CDP4Composition.Extensions
             }
 
             return allowedOwners.OrderBy(domain => domain.Name).ToList();
+        }
+
+        /// <summary>
+        /// Resolves the <see cref="Iteration"/> to use when querying the allowed owner <see cref="DomainOfExpertise"/>s
+        /// of an <see cref="IOwnedThing"/> whose <paramref name="container"/> is a <see cref="FileStore"/> or a
+        /// <see cref="Folder"/> nested in one.
+        /// </summary>
+        /// <param name="session">
+        /// The <see cref="ISession"/> whose open <see cref="Iteration"/>s are inspected for the <see cref="CommonFileStore"/> case.
+        /// </param>
+        /// <param name="container">
+        /// The container <see cref="Thing"/> of the edited <see cref="IOwnedThing"/>.
+        /// </param>
+        /// <returns>
+        /// The owning <see cref="Iteration"/>, or an open <see cref="Iteration"/> of the containing
+        /// <see cref="EngineeringModel"/> when the thing lives in a <see cref="CommonFileStore"/>; null if none can be resolved.
+        /// </returns>
+        /// <remarks>
+        /// Things in a <see cref="DomainFileStore"/> are contained (indirectly) by an <see cref="Iteration"/>, but things in a
+        /// <see cref="CommonFileStore"/> are contained by the <see cref="EngineeringModel"/> directly, so no <see cref="Iteration"/>
+        /// is found by walking the containers. In that case an open <see cref="Iteration"/> of the model is used, since the allowed
+        /// owners of a <see cref="Participant"/> are the same for every <see cref="Iteration"/> of the model. See GitHub issue #1490.
+        /// </remarks>
+        public static Iteration QueryOwnedThingIteration(this ISession session, Thing container)
+        {
+            return container.GetContainerOfType<Iteration>()
+                   ?? container.GetContainerOfType<EngineeringModel>()?.Iteration.FirstOrDefault(session.OpenIterations.ContainsKey);
         }
     }
 }

--- a/CDP4Composition/Mvvm/MenuItems/RibbonButtonEngineeringModelDependentViewModel.cs
+++ b/CDP4Composition/Mvvm/MenuItems/RibbonButtonEngineeringModelDependentViewModel.cs
@@ -137,7 +137,7 @@ namespace CDP4Composition.Mvvm
         /// <param name="engineeringModel">the engineering model</param>
         protected virtual void EngineeringModelRemovedEventHandler(EngineeringModel engineeringModel)
         {
-            var sessionEngineeringModelSetupMenuGroupViewModel = this.EngineeringModels.SingleOrDefault(x => x.Thing == engineeringModel.Container);
+            var sessionEngineeringModelSetupMenuGroupViewModel = this.EngineeringModels.SingleOrDefault(x => x.Thing == engineeringModel);
 
             if (sessionEngineeringModelSetupMenuGroupViewModel == null)
             {

--- a/CDP4Composition/RelationshipClassKinds.cs
+++ b/CDP4Composition/RelationshipClassKinds.cs
@@ -49,7 +49,8 @@ namespace CDP4Composition
             ClassKind.ParametricConstraint,
             ClassKind.RequirementsSpecification,
             ClassKind.RequirementsGroup,
-            ClassKind.Requirement
+            ClassKind.Requirement,
+            ClassKind.File
         };
     }
 }

--- a/CDP4RelationshipEditor.Tests/RelationshipEditorViewModelTestFixture.cs
+++ b/CDP4RelationshipEditor.Tests/RelationshipEditorViewModelTestFixture.cs
@@ -28,6 +28,7 @@ namespace CDP4RelationshipEditor.Tests
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Windows;
 
     using CDP4Common.CommonData;
@@ -35,15 +36,23 @@ namespace CDP4RelationshipEditor.Tests
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
+    using CDP4Composition.Diagram;
     using CDP4Composition.DragDrop;
+    using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services;
 
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
     using CDP4Dal.Permission;
 
     using CDP4RelationshipEditor.ViewModels;
+
+    using CommonServiceLocator;
+
+    using DevExpress.Xpf.Diagram;
 
     using Moq;
 
@@ -56,6 +65,8 @@ namespace CDP4RelationshipEditor.Tests
         private Mock<IPermissionService> permissionService;
         private Mock<IThingDialogNavigationService> thingDialogNavigationService;
         private Mock<IPanelNavigationService> panelNavigationService;
+        private Mock<IServiceLocator> serviceLocator;
+        private Mock<IMessageBoxService> messageBoxService;
         private Mock<IDropInfo> dropinfo;
         private readonly Uri uri = new Uri("http://test.com");
         private Assembler assembler;
@@ -79,6 +90,11 @@ namespace CDP4RelationshipEditor.Tests
             this.assembler = new Assembler(this.uri, this.messageBus);
             this.permissionService = new Mock<IPermissionService>();
             this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+
+            this.messageBoxService = new Mock<IMessageBoxService>();
+            this.serviceLocator = new Mock<IServiceLocator>();
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
+            this.serviceLocator.Setup(x => x.GetInstance<IMessageBoxService>()).Returns(this.messageBoxService.Object);
             this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();
             this.panelNavigationService = new Mock<IPanelNavigationService>();
             this.dropinfo = new Mock<IDropInfo>();
@@ -123,6 +139,27 @@ namespace CDP4RelationshipEditor.Tests
         public void TearDown()
         {
             this.messageBus.ClearSubscriptions();
+        }
+
+        [Test]
+        [Apartment(ApartmentState.STA)]
+        public void VerifyThatRelationshipToCommonFileStoreFileIsBlocked()
+        {
+            // A CommonFileStore file lives in the EngineeringModel partition, so it cannot be a relationship endpoint (see GitHub issue #1490)
+            var commonFileStore = new CommonFileStore(Guid.NewGuid(), this.cache, this.uri) { Container = this.model };
+            this.model.CommonFileStore.Add(commonFileStore);
+            var file = new File(Guid.NewGuid(), this.cache, this.uri) { Container = commonFileStore };
+            commonFileStore.File.Add(file);
+
+            var viewModel = new RelationshipEditorViewModel(this.iteration, this.participant, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null)
+            {
+                SelectedItems = new ReactiveList<DiagramItem> { new NamedThingDiagramContentItem(file, this.messageBus) }
+            };
+
+            viewModel.CreateMultiRelationshipCommandExecute();
+
+            this.messageBoxService.Verify(x => x.Show(It.IsAny<string>(), "Cannot create relationship", MessageBoxButton.OK, MessageBoxImage.Warning), Times.Once);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
         }
 
         [Test]

--- a/CDP4RelationshipEditor/ViewModels/RelationshipEditorViewModel.cs
+++ b/CDP4RelationshipEditor/ViewModels/RelationshipEditorViewModel.cs
@@ -48,6 +48,7 @@ namespace CDP4RelationshipEditor.ViewModels
     using CDP4Composition.Navigation.Events;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+    using CDP4Composition.Services;
 
     using CDP4Dal;
     using CDP4Dal.Events;
@@ -55,6 +56,8 @@ namespace CDP4RelationshipEditor.ViewModels
 
     using CDP4RelationshipEditor.Controls;
     using CDP4RelationshipEditor.Helpers;
+
+    using CommonServiceLocator;
 
     using DevExpress.Xpf.Diagram;
 
@@ -69,6 +72,11 @@ namespace CDP4RelationshipEditor.ViewModels
         /// Backing field for <see cref="ThingDiagramItems"/>
         /// </summary>
         private ReactiveList<object> thingDiagramItems;
+
+        /// <summary>
+        /// The <see cref="IMessageBoxService"/> used to warn about invalid relationship endpoints
+        /// </summary>
+        private readonly IMessageBoxService messageBoxService;
 
         /// <summary>
         /// Backing field for <see cref="SelectedItems"/>
@@ -122,6 +130,8 @@ namespace CDP4RelationshipEditor.ViewModels
         {
             this.Caption = string.Format("{0}, iteration_{1}", PanelCaption, this.Thing.IterationSetup.IterationNumber);
             this.ToolTip = string.Format("{0}\n{1}\n{2}", ((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+
+            this.messageBoxService = ServiceLocator.Current.GetInstance<IMessageBoxService>();
 
             this.AddSubscriptions();
             this.UpdateProperties();
@@ -381,6 +391,37 @@ namespace CDP4RelationshipEditor.ViewModels
         }
 
         /// <summary>
+        /// Asserts whether all <paramref name="things"/> can be used as endpoints of a relationship created in this editor's <see cref="Iteration"/>,
+        /// showing a friendly message and returning false when one of them cannot.
+        /// </summary>
+        /// <param name="things">The <see cref="Thing"/>s that would become the source/target/related things of the relationship.</param>
+        /// <returns>true when every <see cref="Thing"/> is a valid endpoint; otherwise false.</returns>
+        /// <remarks>
+        /// A <see cref="BinaryRelationship"/>/<see cref="MultiRelationship"/> is contained by the <see cref="Iteration"/> and the data-source
+        /// requires its endpoints to live in the same iteration partition. A <see cref="File"/> of a <see cref="CommonFileStore"/> lives in the
+        /// EngineeringModel partition instead, so relating it fails server-side with a foreign-key error; catch that here (see GitHub issue #1490).
+        /// </remarks>
+        private bool AreValidRelationshipEndpoints(IReadOnlyList<Thing> things)
+        {
+            var invalidThing = things.FirstOrDefault(thing => thing.GetContainerOfType<Iteration>() == null);
+
+            if (invalidThing == null)
+            {
+                return true;
+            }
+
+            var invalidThingName = invalidThing is File file ? file.CurrentFileRevision?.Name : invalidThing.UserFriendlyName;
+
+            this.messageBoxService.Show(
+                $"'{invalidThingName}' cannot be linked in a relationship because it is not part of the iteration. Files in a Common File Store are stored at the model level; move the file to a Domain File Store to relate it.",
+                "Cannot create relationship",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+
+            return false;
+        }
+
+        /// <summary>
         /// Creates a <see cref="MultiRelationship"/>
         /// </summary>
         /// <param name="rule">
@@ -399,6 +440,13 @@ namespace CDP4RelationshipEditor.ViewModels
         /// <param name="rule">The <see cref="MultiRelationshipRule"/> that defines this relationship.</param>
         private async void CreateMultiRelationship(IEnumerable<Thing> relatableThings, MultiRelationshipRule rule)
         {
+            var relatableThingList = relatableThings.ToList();
+
+            if (!this.AreValidRelationshipEndpoints(relatableThingList))
+            {
+                return;
+            }
+
             // send off the relationship
             Tuple<DomainOfExpertise, Participant> tuple;
             this.Session.OpenIterations.TryGetValue(this.Thing, out tuple);
@@ -415,7 +463,7 @@ namespace CDP4RelationshipEditor.ViewModels
 
             multiRelationship.Container = iteration;
 
-            multiRelationship.RelatedThing = relatableThings.ToList();
+            multiRelationship.RelatedThing = relatableThingList;
 
             var transactionContext = TransactionContextResolver.ResolveContext(this.Thing);
 
@@ -461,6 +509,13 @@ namespace CDP4RelationshipEditor.ViewModels
             }
 
             if (beginItemContent.Thing == endItemContent.Thing)
+            {
+                this.Behavior.RemoveItem(connector);
+                this.Behavior.ResetTool();
+                return;
+            }
+
+            if (!this.AreValidRelationshipEndpoints(new[] { beginItemContent.Thing, endItemContent.Thing }))
             {
                 this.Behavior.RemoveItem(connector);
                 this.Behavior.ResetTool();

--- a/EngineeringModel.Tests/ViewModels/Dialogs/FileDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/Dialogs/FileDialogViewModelTestFixture.cs
@@ -266,5 +266,31 @@ namespace CDP4EngineeringModel.Tests.ViewModels.Dialogs
             vm.SelectedLockedBy = otherPerson;
             Assert.IsFalse(vm.OkCanExecute);
         }
+
+        [Test]
+        public void VerifyThatOwnerIsPopulatedForFileInCommonFileStore()
+        {
+            // A CommonFileStore hangs off the EngineeringModel, so its File has no Iteration container.
+            // Session.QueryDomainOfExpertise dereferences a null Iteration - simulate that here (see GitHub issue #1490).
+            this.session.Setup(x => x.QueryDomainOfExpertise(null)).Throws<NullReferenceException>();
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.Is<Iteration>(i => i != null))).Returns(new[] { this.domain });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.Is<Iteration>(i => i != null))).Returns(this.domain);
+
+            var commonFileStore = new CommonFileStore(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.model };
+            this.model.CommonFileStore.Add(commonFileStore);
+            var commonFileStoreClone = commonFileStore.Clone(false);
+            var newFile = new File(Guid.NewGuid(), this.assembler.Cache, this.uri);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(commonFileStore);
+            var transaction = new ThingTransaction(transactionContext, commonFileStoreClone);
+
+            FileDialogViewModel vm = null;
+
+            Assert.DoesNotThrow(() =>
+                vm = new FileDialogViewModel(newFile, transaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, commonFileStoreClone));
+
+            Assert.That(vm.PossibleOwner, Is.Not.Empty);
+            Assert.That(vm.SelectedOwner, Is.EqualTo(this.domain));
+        }
     }
 }

--- a/EngineeringModel.Tests/ViewModels/Dialogs/FileDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/Dialogs/FileDialogViewModelTestFixture.cs
@@ -289,8 +289,11 @@ namespace CDP4EngineeringModel.Tests.ViewModels.Dialogs
             Assert.DoesNotThrow(() =>
                 vm = new FileDialogViewModel(newFile, transaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, commonFileStoreClone));
 
-            Assert.That(vm.PossibleOwner, Is.Not.Empty);
-            Assert.That(vm.SelectedOwner, Is.EqualTo(this.domain));
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm.PossibleOwner, Is.Not.Empty);
+                Assert.That(vm.SelectedOwner, Is.EqualTo(this.domain));
+            });
         }
     }
 }

--- a/EngineeringModel.Tests/ViewModels/Dialogs/FolderDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/Dialogs/FolderDialogViewModelTestFixture.cs
@@ -244,8 +244,11 @@ namespace CDP4EngineeringModel.Tests.Dialogs
                 new FolderDialogViewModel(newFolder, transaction, this.session.Object, true, ThingDialogKind.Create,
                     this.thingDialogNavigationService.Object, commonFileStoreClone);
 
-            Assert.That(folderDialogViewModel.PossibleOwner, Is.Not.Empty);
-            Assert.That(folderDialogViewModel.SelectedOwner, Is.EqualTo(this.domainOfExpertise));
+            Assert.Multiple(() =>
+            {
+                Assert.That(folderDialogViewModel.PossibleOwner, Is.Not.Empty);
+                Assert.That(folderDialogViewModel.SelectedOwner, Is.EqualTo(this.domainOfExpertise));
+            });
         }
     }
 }

--- a/EngineeringModel.Tests/ViewModels/Dialogs/FolderDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/Dialogs/FolderDialogViewModelTestFixture.cs
@@ -226,5 +226,26 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             folderDialogViewModel.SelectedOwner = this.domainOfExpertise;
             Assert.IsTrue(folderDialogViewModel.OkCanExecute);
         }
+
+        [Test]
+        public void VerifyThatOwnerIsPopulatedForFolderInCommonFileStore()
+        {
+            // A CommonFileStore hangs off the EngineeringModel, so its Folder has no Iteration container.
+            // The owner picker must still be populated from an open iteration of the model (see GitHub issue #1490).
+            var commonFileStore = new CommonFileStore(Guid.NewGuid(), this.cache, this.uri) { Container = this.engineeringModel };
+            this.engineeringModel.CommonFileStore.Add(commonFileStore);
+            var commonFileStoreClone = commonFileStore.Clone(false);
+            var newFolder = new Folder(Guid.NewGuid(), this.cache, this.uri);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(commonFileStore);
+            var transaction = new ThingTransaction(transactionContext, commonFileStoreClone);
+
+            var folderDialogViewModel =
+                new FolderDialogViewModel(newFolder, transaction, this.session.Object, true, ThingDialogKind.Create,
+                    this.thingDialogNavigationService.Object, commonFileStoreClone);
+
+            Assert.That(folderDialogViewModel.PossibleOwner, Is.Not.Empty);
+            Assert.That(folderDialogViewModel.SelectedOwner, Is.EqualTo(this.domainOfExpertise));
+        }
     }
 }

--- a/EngineeringModel.Tests/ViewModels/FileStoreBrowsers/CommonFileStoreBrowserRibbonViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/FileStoreBrowsers/CommonFileStoreBrowserRibbonViewModelTestFixture.cs
@@ -40,6 +40,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.CommonFileStoreBrowser
     using CDP4Composition.PluginSettingService;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
     using CDP4Dal.Permission;
 
     using CDP4EngineeringModel.ViewModels;
@@ -160,6 +161,22 @@ namespace CDP4EngineeringModel.Tests.ViewModels.CommonFileStoreBrowser
                 this.pluginSettingsService.Object);
 
             Assert.IsInstanceOf<CommonFileStoreBrowserViewModel>(viewmodel);
+        }
+
+        [Test]
+        public void VerifyThatModelMenuGroupIsRemovedWhenModelIsClosed()
+        {
+            var viewmodel = new CommonFileStoreBrowserRibbonViewModel(this.messageBus);
+
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.Open));
+            this.messageBus.SendObjectChangeEvent(this.model, EventKind.Added);
+
+            Assert.That(viewmodel.EngineeringModels, Has.Count.EqualTo(1));
+
+            // Closing the model removes the EngineeringModel; the ribbon must then close its panels and drop the menu group (see GitHub issue #1381)
+            this.messageBus.SendObjectChangeEvent(this.model, EventKind.Removed);
+
+            Assert.That(viewmodel.EngineeringModels, Is.Empty);
         }
     }
 }

--- a/EngineeringModel.Tests/ViewModels/FileStoreBrowsers/FolderRowViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/FileStoreBrowsers/FolderRowViewModelTestFixture.cs
@@ -27,6 +27,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Reflection;
     using System.Threading.Tasks;
     using System.Windows;
@@ -193,6 +194,14 @@ namespace CDP4EngineeringModel.Tests.ViewModels
 
             await row.Drop(dropinfo.Object);
             this.session.VerifyGet(x => x.OpenIterations, Times.Once);
+        }
+
+        [Test]
+        public void VerifyThatCreationDateIsPopulatedAndConsistentlyFormatted()
+        {
+            var row = new FolderRowViewModel(this.folder1, this.session.Object, null, this.fileStoreFileAndFolderHandler.Object);
+
+            Assert.That(row.CreationDate, Is.EqualTo(this.folder1.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture)));
         }
 
         [Test]

--- a/EngineeringModel/ViewModels/Dialogs/FileDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/FileDialogViewModel.cs
@@ -219,7 +219,13 @@ namespace CDP4EngineeringModel.ViewModels
         protected override void PopulatePossibleOwner()
         {
             base.PopulatePossibleOwner();
-            var iteration = this.Container.GetContainerOfType<Iteration>();
+            var iteration = this.Session.QueryOwnedThingIteration(this.Container);
+
+            if (iteration == null)
+            {
+                return;
+            }
+
             this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
             this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
 

--- a/EngineeringModel/ViewModels/Dialogs/FolderDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/FolderDialogViewModel.cs
@@ -106,7 +106,7 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleOwner();
 
-            var iteration = this.Container.GetContainerOfType<Iteration>();
+            var iteration = this.Session.QueryOwnedThingIteration(this.Container);
 
             if (iteration == null)
             {

--- a/EngineeringModel/ViewModels/FileStoreBrowsers/CommonFileStoreRowViewModel.cs
+++ b/EngineeringModel/ViewModels/FileStoreBrowsers/CommonFileStoreRowViewModel.cs
@@ -36,11 +36,14 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4EngineeringModel.ViewModels.FileStoreBrowsers;
     using System.Threading.Tasks;
     using System;
+    using System.Globalization;
     using System.Linq;
     using System.Windows;
 
     using CDP4Composition.DragDrop;
     using CDP4Composition.Extensions;
+
+    using ReactiveUI;
 
     /// <summary>
     /// The <see cref="CommonFileStore"/> row-view-model
@@ -53,6 +56,11 @@ namespace CDP4EngineeringModel.ViewModels
         private readonly IFileStoreFileAndFolderHandler fileStoreFileAndFolderHandler;
 
         /// <summary>
+        /// Backing field for the <see cref="CreationDate"/> property
+        /// </summary>
+        private string creationDate;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CommonFileStoreRowViewModel"/> class
         /// </summary>
         /// <param name="store">The associated <see cref="CommonFileStore"/></param>
@@ -63,6 +71,15 @@ namespace CDP4EngineeringModel.ViewModels
         {
             this.fileStoreFileAndFolderHandler = new FileStoreFileAndFolderHandler<CommonFileStore>(this);
             this.UpdateProperties();
+        }
+
+        /// <summary>
+        /// Gets the date of creation of the <see cref="CommonFileStore"/>, formatted consistently with the other file-store rows
+        /// </summary>
+        public string CreationDate
+        {
+            get => this.creationDate;
+            private set => this.RaiseAndSetIfChanged(ref this.creationDate, value);
         }
 
         /// <summary>
@@ -84,6 +101,7 @@ namespace CDP4EngineeringModel.ViewModels
         private void UpdateProperties()
         {
             this.fileStoreFileAndFolderHandler.UpdateFileRows();
+            this.CreationDate = this.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture);
         }
 
                /// <summary>

--- a/EngineeringModel/ViewModels/FileStoreBrowsers/FolderRowViewModel.cs
+++ b/EngineeringModel/ViewModels/FileStoreBrowsers/FolderRowViewModel.cs
@@ -125,7 +125,7 @@ namespace CDP4EngineeringModel.ViewModels
         /// </summary>
         private void UpdateCreationDate()
         {
-            this.CreationDate = this.Thing.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture);
+            this.CreationDate = this.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/FileStoreBrowsers/FolderRowViewModel.cs
+++ b/EngineeringModel/ViewModels/FileStoreBrowsers/FolderRowViewModel.cs
@@ -26,6 +26,7 @@
 namespace CDP4EngineeringModel.ViewModels
 {
     using System;
+    using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
     using System.Windows;
@@ -43,6 +44,8 @@ namespace CDP4EngineeringModel.ViewModels
 
     using CommonServiceLocator;
 
+    using ReactiveUI;
+
     /// <summary>
     /// The folder row view model.
     /// </summary>
@@ -59,7 +62,12 @@ namespace CDP4EngineeringModel.ViewModels
         private readonly IMessageBoxService messageBoxService = ServiceLocator.Current.GetInstance<IMessageBoxService>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FolderRowViewModel"/> class. 
+        /// Backing field for the <see cref="CreationDate"/> property
+        /// </summary>
+        private string creationDate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FolderRowViewModel"/> class.
         /// </summary>
         /// <param name="folder">
         /// The <see cref="Folder"/> associated with this row
@@ -77,6 +85,16 @@ namespace CDP4EngineeringModel.ViewModels
             : base(folder, session, containerViewModel)
         {
             this.parentFileStoreFileAndFolderHandler = parentFileStoreFileAndFolderHandler;
+            this.UpdateCreationDate();
+        }
+
+        /// <summary>
+        /// Gets the date of creation of the <see cref="Folder"/>, formatted consistently with the other file-store rows
+        /// </summary>
+        public string CreationDate
+        {
+            get => this.creationDate;
+            private set => this.RaiseAndSetIfChanged(ref this.creationDate, value);
         }
 
         /// <summary>
@@ -98,7 +116,16 @@ namespace CDP4EngineeringModel.ViewModels
         protected override void ObjectChangeEventHandler(ObjectChangedEvent objectChange)
         {
             base.ObjectChangeEventHandler(objectChange);
+            this.UpdateCreationDate();
             this.parentFileStoreFileAndFolderHandler?.UpdateFolderRowPosition(this.Thing);
+        }
+
+        /// <summary>
+        /// Updates the <see cref="CreationDate"/> property from the <see cref="Folder"/>'s creation date
+        /// </summary>
+        private void UpdateCreationDate()
+        {
+            this.CreationDate = this.Thing.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/EngineeringModel/Views/FileStoreBrowsers/CommonFileStoreBrowser.xaml
+++ b/EngineeringModel/Views/FileStoreBrowsers/CommonFileStoreBrowser.xaml
@@ -151,7 +151,7 @@
             <dxg:TreeListControl.Columns>
                 <dxg:TreeListColumn FieldName="Name" />
                 <dxg:TreeListColumn FieldName="CreatorValue" Header="Creator" />
-                <dxg:TreeListColumn FieldName="CreatedOn" Header="Created on" />
+                <dxg:TreeListColumn FieldName="CreationDate" Header="Created on" />
                 <dxg:TreeListColumn FieldName="Locker" Header="Locked by" />
             </dxg:TreeListControl.Columns>
 

--- a/RelationshipMatrix.Tests/RelationshipMatrixModuleTestFixture.cs
+++ b/RelationshipMatrix.Tests/RelationshipMatrixModuleTestFixture.cs
@@ -25,11 +25,15 @@
 
 namespace CDP4RelationshipMatrix.Tests
 {
+    using CDP4Common.CommonData;
+
     using CDP4Composition;
     using CDP4Composition.Exceptions;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
+    using CDP4RelationshipMatrix.Settings;
 
     using CommonServiceLocator;
 
@@ -85,6 +89,22 @@ namespace CDP4RelationshipMatrix.Tests
             Assert.DoesNotThrow(() => this.relationshipMatrixModule.ReadPluginSettings());
 
             this.pluginSettingsService.Verify(x => x.Write(It.IsAny<RelationshipMatrixPluginSettings>()));
+        }
+
+        [Test]
+        public void Verify_that_class_kinds_added_to_the_defaults_are_merged_into_an_existing_settings_file()
+        {
+            // A settings file written before File was a possible source/target must still gain it (see GitHub issue #1490)
+            var existingSettings = new RelationshipMatrixPluginSettings();
+            existingSettings.PossibleClassKinds.Add(ClassKind.ElementDefinition);
+            existingSettings.PossibleDisplayKinds.Add(DisplayKind.Name);
+
+            this.pluginSettingsService.Setup(x => x.Read<RelationshipMatrixPluginSettings>(false)).Returns(existingSettings);
+
+            this.relationshipMatrixModule.ReadPluginSettings();
+
+            Assert.That(existingSettings.PossibleClassKinds, Does.Contain(ClassKind.File));
+            this.pluginSettingsService.Verify(x => x.Write(existingSettings));
         }
     }
 }

--- a/RelationshipMatrix.Tests/ViewModel/MatrixItemExtensionsTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/MatrixItemExtensionsTestFixture.cs
@@ -47,8 +47,11 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
         {
             var elementDefinition = new ElementDefinition(Guid.NewGuid(), null, this.uri) { Name = "battery", ShortName = "bat" };
 
-            Assert.That(elementDefinition.QueryDisplayName(), Is.EqualTo("battery"));
-            Assert.That(elementDefinition.QueryDisplayShortName(), Is.EqualTo("bat"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(elementDefinition.QueryDisplayName(), Is.EqualTo("battery"));
+                Assert.That(elementDefinition.QueryDisplayShortName(), Is.EqualTo("bat"));
+            });
         }
 
         [Test]
@@ -60,8 +63,11 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
             file.FileRevision.Add(firstRevision);
             file.FileRevision.Add(lastRevision);
 
-            Assert.That(file.QueryDisplayName(), Is.EqualTo("geometry.stp"));
-            Assert.That(file.QueryDisplayShortName(), Is.EqualTo("geometry.stp"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(file.QueryDisplayName(), Is.EqualTo("geometry.stp"));
+                Assert.That(file.QueryDisplayShortName(), Is.EqualTo("geometry.stp"));
+            });
         }
     }
 }

--- a/RelationshipMatrix.Tests/ViewModel/MatrixItemExtensionsTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/MatrixItemExtensionsTestFixture.cs
@@ -1,0 +1,67 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MatrixItemExtensionsTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4RelationshipMatrix.Tests.ViewModel
+{
+    using System;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4RelationshipMatrix.ViewModels;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="MatrixItemExtensions"/> class.
+    /// </summary>
+    [TestFixture]
+    public class MatrixItemExtensionsTestFixture
+    {
+        private readonly Uri uri = new Uri("http://starion.test.com");
+
+        [Test]
+        public void VerifyThatDefinedThingUsesItsNameAndShortName()
+        {
+            var elementDefinition = new ElementDefinition(Guid.NewGuid(), null, this.uri) { Name = "battery", ShortName = "bat" };
+
+            Assert.That(elementDefinition.QueryDisplayName(), Is.EqualTo("battery"));
+            Assert.That(elementDefinition.QueryDisplayShortName(), Is.EqualTo("bat"));
+        }
+
+        [Test]
+        public void VerifyThatFileUsesCurrentRevisionNameAsNameAndShortName()
+        {
+            var file = new File(Guid.NewGuid(), null, this.uri);
+            var firstRevision = new FileRevision(Guid.NewGuid(), null, this.uri) { Name = "old.stp", CreatedOn = new DateTime(2024, 1, 1) };
+            var lastRevision = new FileRevision(Guid.NewGuid(), null, this.uri) { Name = "geometry.stp", CreatedOn = new DateTime(2024, 6, 1) };
+            file.FileRevision.Add(firstRevision);
+            file.FileRevision.Add(lastRevision);
+
+            Assert.That(file.QueryDisplayName(), Is.EqualTo("geometry.stp"));
+            Assert.That(file.QueryDisplayShortName(), Is.EqualTo("geometry.stp"));
+        }
+    }
+}

--- a/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
@@ -207,10 +207,14 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
             vm.SourceXConfiguration.SelectedOwners.Add(this.domain);
 
             // The File shows up as a row (it would be silently dropped before File support was added)
-            Assert.That(vm.Matrix.Records, Is.Not.Empty);
+            var fileRow = vm.Matrix.Records.FirstOrDefault(row => row.Values.First().SourceY == file);
 
-            var fileRow = vm.Matrix.Records.Single(row => row.Values.First().SourceY == file);
-            Assert.That(fileRow.Values.First().SourceY.QueryDisplayShortName(), Is.EqualTo("geometry.stp"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm.Matrix.Records, Is.Not.Empty);
+                Assert.That(fileRow, Is.Not.Null);
+                Assert.That(fileRow?.Values.First().SourceY.QueryDisplayShortName(), Is.EqualTo("geometry.stp"));
+            });
 
             vm.Dispose();
         }

--- a/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
@@ -25,13 +25,16 @@
 
 namespace CDP4RelationshipMatrix.Tests.ViewModel
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reactive.Linq;
     using System.Threading.Tasks;
 
     using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal.Events;
 
@@ -148,6 +151,66 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
 
             Assert.AreEqual(2, vm.Matrix.Records.Count);
             Assert.AreEqual(2, vm.Matrix.Columns.Count);
+
+            vm.Dispose();
+        }
+
+        [Test]
+        public void AssertFileCanBeUsedAsMatrixSource()
+        {
+            // #1490: a File is not a DefinedThing; it must still flow through the matrix, using its current revision name as name and short-name.
+            var fileCategory = new Category(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "geometry", ShortName = "geometry" };
+            fileCategory.PermissibleClass.Add(ClassKind.File);
+            this.srdl.DefinedCategory.Add(fileCategory);
+            this.assembler.Cache.TryAdd(new CacheKey(fileCategory.Iid, null), new Lazy<Thing>(() => fileCategory));
+
+            var fileRule = new BinaryRelationshipRule(Guid.NewGuid(), this.assembler.Cache, this.uri)
+            {
+                SourceCategory = fileCategory,
+                TargetCategory = this.catEd1,
+                RelationshipCategory = this.catRel,
+                Name = "file-to-element",
+                ShortName = "file-to-element"
+            };
+
+            this.srdl.Rule.Add(fileRule);
+            this.assembler.Cache.TryAdd(new CacheKey(fileRule.Iid, null), new Lazy<Thing>(() => fileRule));
+
+            var fileStore = new DomainFileStore(Guid.NewGuid(), this.assembler.Cache, this.uri) { Owner = this.domain, Container = this.iteration };
+            var file = new File(Guid.NewGuid(), this.assembler.Cache, this.uri) { Owner = this.domain };
+            file.Category.Add(fileCategory);
+            var fileRevision = new FileRevision(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "geometry.stp", CreatedOn = DateTime.UtcNow, Creator = this.participant };
+            file.FileRevision.Add(fileRevision);
+            fileStore.File.Add(file);
+            this.iteration.DomainFileStore.Add(fileStore);
+            this.assembler.Cache.TryAdd(new CacheKey(file.Iid, this.iteration.Iid), new Lazy<Thing>(() => file));
+
+            this.settings.PossibleClassKinds.Add(ClassKind.File);
+
+            var vm = new RelationshipMatrixViewModel(
+                this.iteration,
+                this.session.Object,
+                this.thingDialogNavigationService.Object,
+                this.panelNavigationService.Object,
+                this.dialogNavigationService.Object,
+                this.pluginService.Object);
+
+            vm.SourceYConfiguration.SelectedClassKind = vm.SourceYConfiguration.PossibleClassKinds.First(x => x == ClassKind.File);
+            vm.SourceXConfiguration.SelectedClassKind = vm.SourceXConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
+
+            vm.SourceYConfiguration.SelectedCategories = new List<Category>(vm.SourceYConfiguration.PossibleCategories.Where(x => x.Iid == fileCategory.Iid));
+            vm.SourceXConfiguration.SelectedCategories = new List<Category>(vm.SourceXConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd1.Iid));
+
+            vm.RelationshipConfiguration.SelectedRule = vm.RelationshipConfiguration.PossibleRules.Single(x => x.Iid == fileRule.Iid);
+
+            vm.SourceYConfiguration.SelectedOwners.Add(this.domain);
+            vm.SourceXConfiguration.SelectedOwners.Add(this.domain);
+
+            // The File shows up as a row (it would be silently dropped before File support was added)
+            Assert.That(vm.Matrix.Records, Is.Not.Empty);
+
+            var fileRow = vm.Matrix.Records.Single(row => row.Values.First().SourceY == file);
+            Assert.That(fileRow.Values.First().SourceY.QueryDisplayShortName(), Is.EqualTo("geometry.stp"));
 
             vm.Dispose();
         }

--- a/RelationshipMatrix/Converters/NameContentConverter.cs
+++ b/RelationshipMatrix/Converters/NameContentConverter.cs
@@ -13,6 +13,7 @@ namespace CDP4RelationshipMatrix.Converters
     using System.Windows.Data;
     using CDP4Common.CommonData;
     using DevExpress.Xpf.Grid;
+    using Settings;
     using ViewModels;
 
     /// <summary>
@@ -72,7 +73,14 @@ namespace CDP4RelationshipMatrix.Converters
         {
             var matrixCellViewModel = row[fieldName];
 
-            return matrixCellViewModel?.SourceY is DefinedThing definedThing ? typeof(DefinedThing).GetProperty(matrixCellViewModel.DisplayKind.ToString()).GetValue(matrixCellViewModel.SourceY) : "-";
+            if (matrixCellViewModel?.SourceY == null)
+            {
+                return "-";
+            }
+
+            return matrixCellViewModel.DisplayKind == DisplayKind.Name
+                ? matrixCellViewModel.SourceY.QueryDisplayName()
+                : matrixCellViewModel.SourceY.QueryDisplayShortName();
         }
 
         /// <summary>

--- a/RelationshipMatrix/Helpers/MatrixExcelExporter.cs
+++ b/RelationshipMatrix/Helpers/MatrixExcelExporter.cs
@@ -162,7 +162,7 @@ namespace CDP4RelationshipMatrix.Helpers
             // construct rows
             for (var i = 1; i <= this.Matrix.Records.Count; i++)
             {
-                worksheetMatrix.Cell(i + 1, 1).Value = this.Matrix.Records[i - 1].First().Value.DisplayKind == DisplayKind.Name ? this.Matrix.Records[i - 1].First().Value.SourceY.UserFriendlyName : this.Matrix.Records[i - 1].First().Value.SourceY.UserFriendlyShortName;
+                worksheetMatrix.Cell(i + 1, 1).Value = this.Matrix.Records[i - 1].First().Value.DisplayKind == DisplayKind.Name ? this.Matrix.Records[i - 1].First().Value.SourceY.QueryDisplayName() : this.Matrix.Records[i - 1].First().Value.SourceY.QueryDisplayShortName();
                 var relation = this.Matrix.Records[i - 1].Values.ToList();
 
                 var traceCount = 0;

--- a/RelationshipMatrix/RelationshipMatrixModule.cs
+++ b/RelationshipMatrix/RelationshipMatrixModule.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationshipMatrixModule.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2021 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
 //
@@ -128,10 +128,26 @@ namespace CDP4RelationshipMatrix
             {
                 var settings = this.PluginSettingService.Read<RelationshipMatrixPluginSettings>();
 
+                var settingsChanged = false;
+
                 if (!settings.PossibleDisplayKinds.Any())
                 {
                     // if setting is empty, repopulate with default set and save it
                     settings.PossibleDisplayKinds = RelationshipMatrixPluginSettings.DefaultDisplayKinds.ToList();
+                    settingsChanged = true;
+                }
+
+                // merge in any class-kinds added to the defaults after this settings file was written (e.g. File, see GitHub issue #1490)
+                var missingClassKinds = RelationshipMatrixPluginSettings.DefaultClassKinds.Except(settings.PossibleClassKinds).ToList();
+
+                if (missingClassKinds.Any())
+                {
+                    settings.PossibleClassKinds.AddRange(missingClassKinds);
+                    settingsChanged = true;
+                }
+
+                if (settingsChanged)
+                {
                     this.PluginSettingService.Write(settings);
                 }
             }

--- a/RelationshipMatrix/ViewModels/ColumnDefinition.cs
+++ b/RelationshipMatrix/ViewModels/ColumnDefinition.cs
@@ -60,12 +60,12 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// </summary>
         /// <param name="thing">The represented <see cref="Thing"/></param>
         /// <param name="displayKind">The <see cref="DisplayKind"/> of the column.</param>
-        public ColumnDefinition(DefinedThing thing, DisplayKind displayKind)
+        public ColumnDefinition(Thing thing, DisplayKind displayKind)
         {
             this.RelationshipCount = 0;
-            this.Header = displayKind == DisplayKind.Name ? thing.Name : thing.ShortName;
+            this.Header = displayKind == DisplayKind.Name ? thing.QueryDisplayName() : thing.QueryDisplayShortName();
             this.ToolTip = thing.Tooltip();
-            this.FieldName = thing.ShortName;
+            this.FieldName = thing.QueryDisplayShortName();
             this.ThingId = thing.Iid;
             this.IsHighlighted = false;
         }

--- a/RelationshipMatrix/ViewModels/MatrixItemExtensions.cs
+++ b/RelationshipMatrix/ViewModels/MatrixItemExtensions.cs
@@ -1,0 +1,77 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MatrixItemExtensions.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4RelationshipMatrix.ViewModels
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// Extension methods that resolve the name and short-name of a <see cref="Thing"/> displayed in the relationship matrix.
+    /// </summary>
+    /// <remarks>
+    /// The matrix historically only handled <see cref="DefinedThing"/>s (which carry a <c>Name</c>/<c>ShortName</c>). Kinds such
+    /// as <see cref="File"/> are not <see cref="DefinedThing"/>s and keep their name on the current <see cref="FileRevision"/>,
+    /// so both the name and the short-name of a <see cref="File"/> resolve to that revision's name. See GitHub issue #1490.
+    /// </remarks>
+    public static class MatrixItemExtensions
+    {
+        /// <summary>
+        /// Queries the name to display for the <paramref name="thing"/> in the matrix.
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> shown in a row or column.</param>
+        /// <returns>The name of the <paramref name="thing"/>.</returns>
+        public static string QueryDisplayName(this Thing thing)
+        {
+            switch (thing)
+            {
+                case File file:
+                    return file.CurrentFileRevision?.Name;
+                case DefinedThing definedThing:
+                    return definedThing.Name;
+                default:
+                    return thing?.UserFriendlyName;
+            }
+        }
+
+        /// <summary>
+        /// Queries the short-name to display (and to use as the grid field-name) for the <paramref name="thing"/> in the matrix.
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> shown in a row or column.</param>
+        /// <returns>The short-name of the <paramref name="thing"/>; for a <see cref="File"/> this is its current revision name.</returns>
+        public static string QueryDisplayShortName(this Thing thing)
+        {
+            switch (thing)
+            {
+                case File file:
+                    return file.CurrentFileRevision?.Name;
+                case DefinedThing definedThing:
+                    return definedThing.ShortName;
+                default:
+                    return thing?.UserFriendlyShortName;
+            }
+        }
+    }
+}

--- a/RelationshipMatrix/ViewModels/MatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/MatrixViewModel.cs
@@ -460,30 +460,19 @@ namespace CDP4RelationshipMatrix.ViewModels
                 .Where(x => x.ClassKind == sourceX.SelectedClassKind.Value ||
                             x.ClassKind == sourceY.SelectedClassKind.Value).ToList();
 
-            List<DefinedThing> sourceXThing;
-            List<DefinedThing> sourceYThing;
-
-            try
-            {
-                sourceXThing = things.Where(x => x.ClassKind == sourceX.SelectedClassKind.Value).Cast<DefinedThing>()
-                    .ToList();
-
-                sourceYThing = things.Where(x => x.ClassKind == sourceY.SelectedClassKind.Value).Cast<DefinedThing>()
-                    .ToList();
-            }
-            catch (InvalidCastException)
-            {
-                return;
-            }
+            // Note: only DomainFileStore files (iteration partition) are offered - a BinaryRelationship is iteration-scoped and
+            // the server rejects a target that lives in the EngineeringModel partition, i.e. a CommonFileStore file (see GitHub issue #1490).
+            var sourceXThing = things.Where(x => x.ClassKind == sourceX.SelectedClassKind.Value).ToList();
+            var sourceYThing = things.Where(x => x.ClassKind == sourceY.SelectedClassKind.Value).ToList();
 
             if (sourceYThing.Count == 0 || sourceXThing.Count == 0)
             {
                 return;
             }
 
-            var sourceXToUse = new List<DefinedThing>(this.FilterAndSortSourceByCategoryAndOwner(sourceXThing, sourceX));
+            var sourceXToUse = new List<Thing>(this.FilterAndSortSourceByCategoryAndOwner(sourceXThing, sourceX));
 
-            var sourceYToUse = new List<DefinedThing>(this.FilterAndSortSourceByCategoryAndOwner(sourceYThing, sourceY));
+            var sourceYToUse = new List<Thing>(this.FilterAndSortSourceByCategoryAndOwner(sourceYThing, sourceY));
 
             if (sourceYToUse.Count == 0 || sourceXToUse.Count == 0)
             {
@@ -543,34 +532,34 @@ namespace CDP4RelationshipMatrix.ViewModels
 
             foreach (var relationship in oldRelationships.Union(newRelationships))
             {
-                var definedSource = relationship.Source as DefinedThing;
-                var definedTarget = relationship.Target as DefinedThing;
+                var source = relationship.Source;
+                var target = relationship.Target;
 
-                if (definedSource == null || definedTarget == null)
+                if (source == null || target == null)
                 {
                     continue;
                 }
 
-                var sourceRow = this.QueryRow(relationship.Source.Iid);
-                var targetRow = this.QueryRow(relationship.Target.Iid);
+                var sourceRow = this.QueryRow(source.Iid);
+                var targetRow = this.QueryRow(target.Iid);
 
                 if (sourceRow != null)
                 {
-                    var cellValue = this.ComputeCell(definedSource, definedTarget, updatedRelationships,
+                    var cellValue = this.ComputeCell(source, target, updatedRelationships,
                         relationshipRule, false);
 
-                    sourceRow[definedTarget.ShortName] = cellValue;
-                    this.UpdateCurrentCell(definedSource, definedTarget, cellValue);
+                    sourceRow[target.QueryDisplayShortName()] = cellValue;
+                    this.UpdateCurrentCell(source, target, cellValue);
                 }
 
                 if (targetRow != null)
                 {
-                    var cellValue = this.ComputeCell(definedTarget, definedSource, updatedRelationships,
+                    var cellValue = this.ComputeCell(target, source, updatedRelationships,
                         relationshipRule, false);
 
-                    targetRow[definedSource.ShortName] = cellValue;
+                    targetRow[source.QueryDisplayShortName()] = cellValue;
 
-                    this.UpdateCurrentCell(definedTarget, definedSource, cellValue);
+                    this.UpdateCurrentCell(target, source, cellValue);
                 }
             }
         }
@@ -603,12 +592,12 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <param name="displayKind">The <see cref="DisplayKind" /> of the column.</param>
         /// <param name="showRelatedOnly">Indicate whether to only show related elements.</param>
         /// <param name="relationships">The list of all relationships.</param>
-        private IList<ColumnDefinition> CreateColumns(IReadOnlyList<DefinedThing> source, DisplayKind displayKind,
+        private IList<ColumnDefinition> CreateColumns(IReadOnlyList<Thing> source, DisplayKind displayKind,
             bool showRelatedOnly, IList<BinaryRelationship> relationships)
         {
             var columns = new List<ColumnDefinition>();
 
-            foreach (var definedThing in IEnumerableExtensions.DistinctBy(source, x => x.ShortName))
+            foreach (var definedThing in IEnumerableExtensions.DistinctBy(source, x => x.QueryDisplayShortName()))
             {
                 if (showRelatedOnly && !relationships.Any(x =>
                         x.Source.Iid.Equals(definedThing.Iid) || x.Target.Iid.Equals(definedThing.Iid)))
@@ -617,7 +606,7 @@ namespace CDP4RelationshipMatrix.ViewModels
                     continue;
                 }
 
-                if (columns.Any(x => x.FieldName == definedThing.ShortName))
+                if (columns.Any(x => x.FieldName == definedThing.QueryDisplayShortName()))
                 {
                     // skip duplicated shortname
                     continue;
@@ -647,8 +636,8 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <param name="columnDefinitions">The defined columns.</param>
         /// <param name="showNonRelatedBackgroundColor">Indicates whether a background color should be shown for cells containing non related things</param>
         /// <returns>The <see cref="IDictionary{TKey,TValue}" /> that corresponds to a row</returns>
-        private IDictionary<string, MatrixCellViewModel> ComputeRow(DefinedThing rowThing,
-            IReadOnlyList<DefinedThing> columnThings,
+        private IDictionary<string, MatrixCellViewModel> ComputeRow(Thing rowThing,
+            IReadOnlyList<Thing> columnThings,
             IReadOnlyList<BinaryRelationship> relationships, BinaryRelationshipRule relationshipRule,
             DisplayKind displayKind, IList<ColumnDefinition> columnDefinitions, bool showNonRelatedBackgroundColor)
         {
@@ -685,7 +674,7 @@ namespace CDP4RelationshipMatrix.ViewModels
                 }
 
                 var cellValue = this.ComputeCell(rowThing, definedThing, relationships, relationshipRule, false);
-                record.Add(definedThing.ShortName, cellValue);
+                record.Add(definedThing.QueryDisplayShortName(), cellValue);
 
                 this.UpdateCurrentCell(rowThing, definedThing, cellValue);
 
@@ -704,7 +693,7 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <param name="row">The thing in the current row context</param>
         /// <param name="col">The thing in the current column context</param>
         /// <param name="cellValue">The cell object</param>
-        private void UpdateCurrentCell(DefinedThing row, DefinedThing col, MatrixCellViewModel cellValue)
+        private void UpdateCurrentCell(Thing row, Thing col, MatrixCellViewModel cellValue)
         {
             var cellRef = $"{row.Iid}_{col.Iid}";
 
@@ -720,7 +709,7 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <param name="relationshipRule">The current <see cref="BinaryRelationshipRule" /></param>
         /// <param name="showNonRelatedBackgroundColor">Indicates whether a background color should be shown for cells containing non related things</param>
         /// <returns>The <see cref="MatrixCellViewModel" /></returns>
-        private MatrixCellViewModel ComputeCell(DefinedThing rowThing, DefinedThing columnThing,
+        private MatrixCellViewModel ComputeCell(Thing rowThing, Thing columnThing,
             IReadOnlyList<BinaryRelationship> relationships, BinaryRelationshipRule relationshipRule, bool showNonRelatedBackgroundColor)
         {
             var relationship = relationships.Where(x =>
@@ -762,10 +751,10 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <param name="source">The <see cref="Thing" /> to filter</param>
         /// <param name="sourceConfigurationViewModel">The filter and sort settings</param>
         /// <returns>The filtered <see cref="Thing" /></returns>
-        private IEnumerable<DefinedThing> FilterAndSortSourceByCategoryAndOwner(IReadOnlyList<DefinedThing> source,
+        private IEnumerable<Thing> FilterAndSortSourceByCategoryAndOwner(IReadOnlyList<Thing> source,
             SourceConfigurationViewModel sourceConfigurationViewModel)
         {
-            var sourceXCatThing = new List<DefinedThing>();
+            var sourceXCatThing = new List<Thing>();
 
             if (sourceConfigurationViewModel?.SelectedCategories == null ||
                 sourceConfigurationViewModel.SelectedCategories.Count == 0)
@@ -826,36 +815,36 @@ namespace CDP4RelationshipMatrix.ViewModels
             if (sourceConfigurationViewModel.SelectedSortOrder == SortOrder.Ascending)
             {
                 sourceXCatThing = sourceConfigurationViewModel.SelectedSortKind == DisplayKind.Name
-                    ? sourceXCatThing.OrderBy(x => x.Name).ToList()
-                    : sourceXCatThing.OrderBy(x => x.ShortName).ToList();
+                    ? sourceXCatThing.OrderBy(x => x.QueryDisplayName()).ToList()
+                    : sourceXCatThing.OrderBy(x => x.QueryDisplayShortName()).ToList();
             }
             else
             {
                 sourceXCatThing = sourceConfigurationViewModel.SelectedSortKind == DisplayKind.Name
-                    ? sourceXCatThing.OrderByDescending(x => x.Name).ToList()
-                    : sourceXCatThing.OrderByDescending(x => x.ShortName).ToList();
+                    ? sourceXCatThing.OrderByDescending(x => x.QueryDisplayName()).ToList()
+                    : sourceXCatThing.OrderByDescending(x => x.QueryDisplayShortName()).ToList();
             }
 
             return sourceXCatThing;
         }
 
         /// <summary>
-        /// Checks if a<see cref="DefinedThing" /> is allowed to be displayed in the UI
+        /// Checks if a <see cref="Thing" /> is allowed to be displayed in the UI
         /// </summary>
-        /// <param name="definedThing">
-        /// The <see cref="DefinedThing" /> to check
+        /// <param name="thing">
+        /// The <see cref="Thing" /> to check
         /// </param>
         /// <returns>
         /// true is display is allowed
         /// </returns>
-        private bool IsDefinedThingDisplayAllowed(DefinedThing definedThing)
+        private bool IsDefinedThingDisplayAllowed(Thing thing)
         {
             if (this.IsDeprecatedDisplayed)
             {
                 return true;
             }
 
-            if (!(definedThing is IDeprecatableThing deprecatableThing))
+            if (!(thing is IDeprecatableThing deprecatableThing))
             {
                 return true;
             }
@@ -1042,11 +1031,11 @@ namespace CDP4RelationshipMatrix.ViewModels
             var selectedRow = this.Records.FirstOrDefault(x => x.SingleOrDefault(y => y.Value == vm).Key != null);
             if (selectedRow != null)
             {
-                var thing = vm.SourceX as DefinedThing;
+                var thing = vm.SourceX;
 
                 var matrixAddress = new MatrixAddress
                 {
-                    Column = thing?.ShortName ?? string.Empty,
+                    Column = thing?.QueryDisplayShortName() ?? string.Empty,
                     Row = this.Records.IndexOf(selectedRow)
                 };
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Summary

Adds the ability to link files to elements (#1490) and fixes several File Store issues found along the way.

### Changes

**Link files to elements (#1490)**
- Files can be related to element definitions using binary and multi relationships. File rows were already draggable, so this works in the Relationship Editor out of the box.
- Relationship Matrix now supports `File` as a source or target. `File` is not a `DefinedThing`, so its current revision name is used as both name and short name. The matrix pipeline was generalized from `DefinedThing` to `Thing`, and existing plugin settings are reconciled with the new class kinds on read so `File` shows up without resetting settings.
- The Relationship Editor now shows the file name for `File` diagram items (previously blank / "not implemented").
- Added a friendly guard: relating a Common File Store file (which lives in the model partition, not the iteration) is blocked with a clear message instead of a raw server foreign key error.

**File dialog owner fix**
- Creating a File or Folder in a Common File Store no longer throws a NullReferenceException, and the owner can now be selected. The dialogs resolve an open iteration of the model when the thing has no iteration container.

**#1381 Common File Store browser not disposed on model close**
- Fixed a lookup mismatch that stopped the panel and its menu item from closing when the model was closed.

**#1139 "Created on" inconsistency in File Store panels**
- Store, folder and file rows now format the creation date consistently across both browsers.


